### PR TITLE
Add uv publish: Basic upload with username/password or keyring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -889,6 +889,61 @@ jobs:
         run: |
           ./uv pip install anyio --reinstall
 
+  integration-test-publish:
+    timeout-minutes: 10
+    needs: build-binary-linux
+    name: "integration test | uv publish"
+    runs-on: ubuntu-latest
+    # Only the main repository is a trusted publisher
+    # TODO(konsti): CHANGE BEFORE MERGE
+    if: github.repository == 'konstin/uv'
+    environment: uv-test-publish
+    env:
+      # No dbus in GitHub Actions
+      PYTHON_KEYRING_BACKEND: keyrings.alt.file.PlaintextKeyring
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Only publish a new release if the
+      - uses: tj-actions/changed-files@v45
+        id: changed
+        with:
+          files_yaml: |
+            code:
+              - "crates/uv-publish/**/*"
+              - "scripts/publish/**/*"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-linux-${{ github.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Add password to keyring"
+        run: |
+          # `keyrings.alt` contains the plaintext keyring
+          ./uv tool install --with keyrings.alt "keyring<25.4.0" # TODO(konsti): Remove upper bound once fix is released
+          echo $UV_TEST_PUBLISH_KEYRING | keyring set https://test.pypi.org/legacy/?astral-test-keyring __token__
+        env:
+          UV_TEST_PUBLISH_KEYRING: ${{ secrets.UV_TEST_PUBLISH_KEYRING }}
+
+      - name: "Publish test packages"
+        if: ${{ steps.changed.outputs.code_any_changed }}
+        # `-p 3.12` prefers the python we just installed over the on locked `.python_version`.
+        run: ./uv run -p 3.12 scripts/publish/test_publish.py --uv ./uv all
+        env:
+          RUST_LOG: uv=debug,uv_publish=trace
+          UV_TEST_PUBLISH_TOKEN: ${{ secrets.UV_TEST_PUBLISH_TOKEN }}
+          UV_TEST_PUBLISH_PASSWORD: ${{ secrets.UV_TEST_PUBLISH_PASSWORD }}
+
   cache-test-ubuntu:
     timeout-minutes: 10
     needs: build-binary-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1326,7 +1326,7 @@ jobs:
         run: echo $(which python)
 
       - name: "Validate global Python install"
-        run: py -3.13 ./scripts/check_system_python.py --uv ./uv.exe --python 3.13
+        run: py -3.13 ./scripts/check_system_python.py --uv ./uv.exe
 
   system-test-choco:
     timeout-minutes: 10
@@ -1405,7 +1405,7 @@ jobs:
         run: echo $(which python3.13)
 
       - name: "Validate global Python install"
-        run: python3.13 scripts/check_system_python.py --uv ./uv --python 3.13
+        run: python3.13 scripts/check_system_python.py --uv ./uv
 
   system-test-conda:
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
               - "docs/reference/cli.md"
               - "docs/reference/settings.md"
               - "uv.schema.json"
-  cargo-fmt:
+  lint:
     timeout-minutes: 10
-    name: "cargo fmt"
+    name: "lint"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +57,9 @@ jobs:
 
       - name: "Install Rustfmt"
         run: rustup component add rustfmt
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v3
 
       - name: "rustfmt"
         run: cargo fmt --all --check
@@ -69,27 +72,13 @@ jobs:
       - name: "README check"
         run: python scripts/transform_readme.py --target pypi
 
-  python-lint:
-    timeout-minutes: 10
-    name: "Python lint"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: "Install uv"
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-
-      - name: "Format"
+      - name: "Python format"
         run: uvx ruff format --diff .
 
-      - name: "Lint"
+      - name: "Python lint"
         run: uvx ruff check .
 
-      - name: "Type check"
+      - name: "Python type check"
         run: uvx mypy
 
   cargo-clippy:
@@ -186,6 +175,7 @@ jobs:
 
       - name: "Install required Python versions"
         run: |
+          # astral-sh/setup-uv sets `UV_CACHE_DIR` which disrupts the help message check
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv python install
 
@@ -226,6 +216,7 @@ jobs:
 
       - name: "Install required Python versions"
         run: |
+          # astral-sh/setup-uv sets `UV_CACHE_DIR` which disrupts the help message check
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv python install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +43,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anes"
@@ -579,6 +597,16 @@ checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
 dependencies = [
  "base64 0.22.1",
  "encoding_rs",
+]
+
+[[package]]
+name = "chumsky"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+dependencies = [
+ "hashbrown",
+ "stacker",
 ]
 
 [[package]]
@@ -1453,6 +1481,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -2132,6 +2164,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,6 +2720,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa37f80ca58604976033fae9515a8a2989fc13797d953f7c04fb8fa36a11f205"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,6 +2857,21 @@ dependencies = [
  "uv-fs",
  "uv-git",
  "uv-normalize",
+]
+
+[[package]]
+name = "python-pkginfo"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3f3f0d552c7efdde2b6898bf21b49c4e76b3e6071ff196dfe52109804db896"
+dependencies = [
+ "flate2",
+ "fs-err",
+ "mailparse",
+ "rfc2047-decoder",
+ "tar",
+ "thiserror",
+ "zip",
 ]
 
 [[package]]
@@ -3090,6 +3156,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3177,6 +3244,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
 dependencies = [
  "rand",
+]
+
+[[package]]
+name = "rfc2047-decoder"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90a668c463c412c3118ae1883e18b53d812c349f5af7a06de3ba4bb0c17cc73"
+dependencies = [
+ "base64 0.21.7",
+ "charset",
+ "chumsky",
+ "memchr",
+ "quoted_printable",
+ "thiserror",
 ]
 
 [[package]]
@@ -3686,6 +3767,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "stacker"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799c883d55abdb5e98af1a7b3f23b9b6de8ecada0ecac058672d7635eb48ca7b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3798,6 +3892,17 @@ name = "tagu"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddb6b06d20fba9ed21fca3d696ee1b6e870bca0bcf9fa2971f6ae2436de576a"
+
+[[package]]
+name = "tar"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -4291,6 +4396,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4510,6 +4624,7 @@ dependencies = [
  "uv-git",
  "uv-installer",
  "uv-normalize",
+ "uv-publish",
  "uv-python",
  "uv-requirements",
  "uv-resolver",
@@ -4982,6 +5097,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "uv-publish"
+version = "0.1.0"
+dependencies = [
+ "async-compression",
+ "base64 0.22.1",
+ "distribution-filename",
+ "fs-err",
+ "futures",
+ "glob",
+ "insta",
+ "itertools 0.13.0",
+ "krata-tokio-tar",
+ "python-pkginfo",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "uv-client",
+ "uv-fs",
+ "uv-metadata",
+ "uv-warnings",
+]
+
+[[package]]
 name = "uv-python"
 version = "0.0.1"
 dependencies = [
@@ -5154,6 +5298,7 @@ dependencies = [
  "thiserror",
  "toml",
  "tracing",
+ "url",
  "uv-cache-info",
  "uv-configuration",
  "uv-fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4863,6 +4863,7 @@ dependencies = [
  "fs2",
  "junction",
  "path-slash",
+ "schemars",
  "serde",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,6 +3118,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "tower-service",
  "url",
@@ -4088,6 +4089,18 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,17 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,7 +190,7 @@ checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -404,18 +393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,24 +426,25 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.12"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+checksum = "50c8f430744b23b54ad15161fcbc22d82a29b73eacbe425fea23ec822600bc6f"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
+ "rancor",
  "simdutf8",
 ]
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.12"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+checksum = "523363cbe1df49b68215efdf500b103ac3b0fb4836aed6d15689a076eadb8fff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -692,7 +670,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -932,7 +910,7 @@ checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown 0.14.5",
+ "hashbrown",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.10",
@@ -1260,12 +1238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,7 +1306,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -1474,15 +1446,6 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -1713,7 +1676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
  "serde",
 ]
 
@@ -2150,7 +2113,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -2206,6 +2169,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64142d38c84badf60abf06ff9bd80ad2174306a5b11bd4706535090a30a419df"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2497,7 +2480,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -2544,7 +2527,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -2696,22 +2679,22 @@ dependencies = [
 
 [[package]]
 name = "ptr_meta"
-version = "0.1.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
 dependencies = [
  "ptr_meta_derive",
 ]
 
 [[package]]
 name = "ptr_meta_derive"
-version = "0.1.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2784,7 +2767,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -2797,7 +2780,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -2889,10 +2872,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
+name = "rancor"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -3045,9 +3031,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rend"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+checksum = "a31c1f1959e4db12c985c0283656be0925f1539549db1e47c4bd0b8b599e1ef7"
 dependencies = [
  "bytecheck",
 ]
@@ -3219,31 +3205,32 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+checksum = "395027076c569819ea6035ee62e664f5e03d74e281744f55261dd1afd939212b"
 dependencies = [
- "bitvec",
  "bytecheck",
  "bytes",
- "hashbrown 0.12.3",
+ "hashbrown",
+ "indexmap",
+ "munge",
  "ptr_meta",
+ "rancor",
  "rend",
  "rkyv_derive",
- "seahash",
  "tinyvec",
  "uuid",
 ]
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.45"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+checksum = "09cb82b74b4810f07e460852c32f522e979787691b0b7b7439fe473e49d49b2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -3459,7 +3446,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -3485,7 +3472,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -3540,7 +3527,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -3551,7 +3538,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -3778,17 +3765,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
@@ -3822,12 +3798,6 @@ name = "tagu"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddb6b06d20fba9ed21fca3d696ee1b6e870bca0bcf9fa2971f6ae2436de576a"
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -3891,7 +3861,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -3902,7 +3872,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
  "test-case-core",
 ]
 
@@ -3924,7 +3894,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -3964,7 +3934,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -4078,7 +4048,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -4211,7 +4181,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -4680,6 +4650,7 @@ dependencies = [
  "async-trait",
  "async_http_range_reader",
  "async_zip",
+ "bytecheck",
  "cache-key",
  "distribution-filename",
  "distribution-types",
@@ -4963,7 +4934,7 @@ version = "0.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
  "textwrap",
 ]
 
@@ -5391,7 +5362,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -5425,7 +5396,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5592,7 +5563,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -5603,7 +5574,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -5614,7 +5585,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -5625,7 +5596,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -5871,15 +5842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "xattr"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5929,7 +5891,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4884,7 +4884,6 @@ dependencies = [
  "tokio",
  "tracing",
  "urlencoding",
- "uv-warnings",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ uv-metadata = { path = "crates/uv-metadata" }
 uv-normalize = { path = "crates/uv-normalize" }
 uv-options-metadata = { path = "crates/uv-options-metadata" }
 uv-pubgrub = { path = "crates/uv-pubgrub" }
+uv-publish = { path = "crates/uv-publish" }
 uv-python = { path = "crates/uv-python" }
 uv-requirements = { path = "crates/uv-requirements" }
 uv-resolver = { path = "crates/uv-resolver" }
@@ -119,12 +120,13 @@ proc-macro2 = { version = "1.0.86" }
 pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "388685a8711092971930986644cfed152d1a1f6c" }
 pyo3 = { version = "0.21.2" }
 pyo3-log = { version = "0.10.0" }
+python-pkginfo = { version = "0.6.3" }
 quote = { version = "1.0.37" }
 rayon = { version = "1.10.0" }
 reflink-copy = { version = "0.1.19" }
 regex = { version = "1.10.6" }
-reqwest = { version = "0.12.7", default-features = false, features = ["json", "gzip", "stream", "rustls-tls", "rustls-tls-native-roots", "socks"] }
-reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913" }
+reqwest = { version = "0.12.7", default-features = false, features = ["json", "gzip", "stream", "rustls-tls", "rustls-tls-native-roots", "socks", "multipart"] }
+reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913", features = ["multipart"] }
 reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913" }
 rkyv = { version = "0.8.8", features = ["bytecheck"] }
 rmp-serde = { version = "1.3.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ axoupdater = { version = "0.7.2", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.22.1" }
 boxcar = { version = "0.2.5" }
+bytecheck = { version = "0.8.0" }
 cachedir = { version = "0.3.1" }
 cargo-util = { version = "0.2.14" }
 clap = { version = "4.5.17" }
@@ -125,7 +126,7 @@ regex = { version = "1.10.6" }
 reqwest = { version = "0.12.7", default-features = false, features = ["json", "gzip", "stream", "rustls-tls", "rustls-tls-native-roots", "socks"] }
 reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913" }
 reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913" }
-rkyv = { version = "0.7.45", features = ["strict", "validation"] }
+rkyv = { version = "0.8.8", features = ["bytecheck"] }
 rmp-serde = { version = "1.3.0" }
 rust-netrc = { version = "0.1.1" }
 rustc-hash = { version = "2.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ quote = { version = "1.0.37" }
 rayon = { version = "1.10.0" }
 reflink-copy = { version = "0.1.19" }
 regex = { version = "1.10.6" }
-reqwest = { version = "0.12.7", default-features = false, features = ["json", "gzip", "stream", "rustls-tls", "rustls-tls-native-roots"] }
+reqwest = { version = "0.12.7", default-features = false, features = ["json", "gzip", "stream", "rustls-tls", "rustls-tls-native-roots", "socks"] }
 reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913" }
 reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913" }
 rkyv = { version = "0.7.45", features = ["strict", "validation"] }

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Initialized project `example` at `/home/user/example`
 $ cd example
 
 $ uv add ruff
-Creating virtualenv at: .venv
+Creating virtual environment at: .venv
 Resolved 2 packages in 170ms
    Built example @ file:///home/user/example
 Prepared 2 packages in 627ms
@@ -155,7 +155,7 @@ Download Python versions as needed:
 ```console
 $ uv venv --python 3.12.0
 Using Python 3.12.0
-Creating virtualenv at: .venv
+Creating virtual environment at: .venv
 Activate with: source .venv/bin/activate
 
 $ uv run --python pypy@3.8 -- python --version
@@ -224,7 +224,7 @@ Create a virtual environment:
 ```console
 $ uv venv
 Using Python 3.12.3
-Creating virtualenv at: .venv
+Creating virtual environment at: .venv
 Activate with: source .venv/bin/activate
 ```
 

--- a/crates/distribution-filename/src/build_tag.rs
+++ b/crates/distribution-filename/src/build_tag.rs
@@ -32,8 +32,7 @@ pub enum BuildTagError {
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct BuildTag(u64, Option<Arc<str>>);
 
 impl FromStr for BuildTag {

--- a/crates/distribution-filename/src/extension.rs
+++ b/crates/distribution-filename/src/extension.rs
@@ -25,8 +25,7 @@ pub enum DistExtension {
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub enum SourceDistExtension {
     Zip,
     TarGz,

--- a/crates/distribution-filename/src/lib.rs
+++ b/crates/distribution-filename/src/lib.rs
@@ -67,6 +67,14 @@ impl DistFilename {
             Self::WheelFilename(filename) => &filename.version,
         }
     }
+
+    /// Whether the file is a `bdist_wheel` or an `sdist`.
+    pub fn filetype(&self) -> &'static str {
+        match self {
+            Self::SourceDistFilename(_) => "sdist",
+            Self::WheelFilename(_) => "bdist_wheel",
+        }
+    }
 }
 
 impl Display for DistFilename {

--- a/crates/distribution-filename/src/source_dist.rs
+++ b/crates/distribution-filename/src/source_dist.rs
@@ -20,8 +20,7 @@ use uv_normalize::{InvalidNameError, PackageName};
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct SourceDistFilename {
     pub name: PackageName,
     pub version: Version,

--- a/crates/distribution-filename/src/wheel.rs
+++ b/crates/distribution-filename/src/wheel.rs
@@ -12,8 +12,7 @@ use uv_normalize::{InvalidNameError, PackageName};
 use crate::{BuildTag, BuildTagError};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct WheelFilename {
     pub name: PackageName,
     pub version: Version,

--- a/crates/distribution-types/src/file.rs
+++ b/crates/distribution-types/src/file.rs
@@ -24,8 +24,7 @@ pub enum FileConversionError {
 #[derive(
     Debug, Clone, Hash, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct File {
     pub dist_info_metadata: bool,
     pub filename: String,
@@ -72,8 +71,7 @@ impl File {
 #[derive(
     Debug, Clone, Hash, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub enum FileLocation {
     /// URL relative to the base URL.
     RelativeUrl(String, String),
@@ -150,8 +148,7 @@ impl Display for FileLocation {
     rkyv::Serialize,
 )]
 #[serde(transparent)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct UrlString(String);
 
 impl UrlString {

--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -27,8 +27,7 @@ use std::{
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
+#[rkyv(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 #[cfg_attr(feature = "pyo3", pyclass)]
 pub enum Operator {
     /// `== 1.2.3`
@@ -288,15 +287,13 @@ impl std::fmt::Display for OperatorParseError {
 /// let version = Version::from_str("1.19").unwrap();
 /// ```
 #[derive(Clone, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
+#[rkyv(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 pub struct Version {
     inner: Arc<VersionInner>,
 }
 
 #[derive(Clone, Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
+#[rkyv(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 enum VersionInner {
     Small { small: VersionSmall },
     Full { full: VersionFull },
@@ -885,8 +882,7 @@ impl FromStr for Version {
 /// Thankfully, such versions are incredibly rare. Virtually all versions have
 /// zero or one pre, dev or post release components.
 #[derive(Clone, Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
+#[rkyv(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 struct VersionSmall {
     /// The representation discussed above.
     repr: u64,
@@ -1227,8 +1223,7 @@ impl VersionSmall {
 /// In general, the "full" representation is rarely used in practice since most
 /// versions will fit into the "small" representation.
 #[derive(Clone, Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
+#[rkyv(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 struct VersionFull {
     /// The [versioning
     /// epoch](https://peps.python.org/pep-0440/#version-epochs). Normally
@@ -1361,8 +1356,7 @@ impl FromStr for VersionPattern {
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
+#[rkyv(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 #[cfg_attr(feature = "pyo3", pyclass)]
 pub struct Prerelease {
     /// The kind of pre-release.
@@ -1387,8 +1381,7 @@ pub struct Prerelease {
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
+#[rkyv(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 #[cfg_attr(feature = "pyo3", pyclass)]
 pub enum PrereleaseKind {
     /// alpha pre-release
@@ -1431,8 +1424,7 @@ impl std::fmt::Display for Prerelease {
 ///
 /// Luckily the default `Ord` implementation for `Vec<LocalSegment>` matches the PEP 440 rules.
 #[derive(Eq, PartialEq, Debug, Clone, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
+#[rkyv(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 pub enum LocalSegment {
     /// Not-parseable as integer segment of local version
     String(String),

--- a/crates/pep440-rs/src/version_specifier.rs
+++ b/crates/pep440-rs/src/version_specifier.rs
@@ -47,8 +47,7 @@ use crate::{
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 #[cfg_attr(feature = "pyo3", pyclass(sequence))]
 pub struct VersionSpecifiers(Vec<VersionSpecifier>);
 
@@ -293,8 +292,7 @@ impl std::error::Error for VersionSpecifiersParseError {}
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 #[cfg_attr(feature = "pyo3", pyclass(get_all))]
 pub struct VersionSpecifier {
     /// ~=|==|!=|<=|>=|<|>|===, plus whether the version ended with a star

--- a/crates/pypi-types/src/simple_json.rs
+++ b/crates/pypi-types/src/simple_json.rs
@@ -99,8 +99,7 @@ impl CoreMetadata {
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 #[serde(untagged)]
 pub enum Yanked {
     Bool(bool),
@@ -303,8 +302,7 @@ impl FromStr for Hashes {
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub enum HashAlgorithm {
     Md5,
     Sha256,
@@ -352,8 +350,7 @@ impl std::fmt::Display for HashAlgorithm {
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct HashDigest {
     pub algorithm: HashAlgorithm,
     pub digest: Box<str>,

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -8,7 +8,7 @@ use crate::{
     realm::Realm,
     CredentialsCache, KeyringProvider, CREDENTIALS_CACHE,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, format_err};
 use netrc::Netrc;
 use reqwest::{Request, Response};
 use reqwest_middleware::{Error, Middleware, Next};
@@ -22,6 +22,11 @@ pub struct AuthMiddleware {
     netrc: Option<Netrc>,
     keyring: Option<KeyringProvider>,
     cache: Option<CredentialsCache>,
+    /// We know that the endpoint needs authentication, so we don't try to send an unauthenticated
+    /// request.
+    ///
+    /// This is also useful since it avoids cloning an unclonable request.
+    only_authenticated: bool,
 }
 
 impl AuthMiddleware {
@@ -30,6 +35,7 @@ impl AuthMiddleware {
             netrc: Netrc::new().ok(),
             keyring: None,
             cache: None,
+            only_authenticated: false,
         }
     }
 
@@ -53,6 +59,16 @@ impl AuthMiddleware {
     #[must_use]
     pub fn with_cache(mut self, cache: CredentialsCache) -> Self {
         self.cache = Some(cache);
+        self
+    }
+
+    /// We know that the endpoint needs authentication, so we don't try to send an unauthenticated
+    /// request.
+    ///
+    /// This is also useful since it avoids cloning an unclonable request.
+    #[must_use]
+    pub fn with_only_authenticated(mut self, only_authenticated: bool) -> Self {
+        self.only_authenticated = only_authenticated;
         self
     }
 
@@ -198,32 +214,42 @@ impl Middleware for AuthMiddleware {
             .as_ref()
             .is_some_and(|credentials| credentials.username().is_some());
 
-        // Otherwise, attempt an anonymous request
-        trace!("Attempting unauthenticated request for {url}");
+        let (mut retry_request, response) = if self.only_authenticated {
+            // For endpoints where we require the user to provide credentials, we don't try the
+            // unauthenticated request first.
+            trace!("Checking for credentials for {url}");
+            (request, None)
+        } else {
+            // Otherwise, attempt an anonymous request
+            trace!("Attempting unauthenticated request for {url}");
 
-        // <https://github.com/TrueLayer/reqwest-middleware/blob/abdf1844c37092d323683c2396b7eefda1418d3c/reqwest-retry/src/middleware.rs#L141-L149>
-        // Clone the request so we can retry it on authentication failure
-        let mut retry_request = request.try_clone().ok_or_else(|| {
-            Error::Middleware(anyhow!(
-                "Request object is not cloneable. Are you passing a streaming body?".to_string()
-            ))
-        })?;
+            // <https://github.com/TrueLayer/reqwest-middleware/blob/abdf1844c37092d323683c2396b7eefda1418d3c/reqwest-retry/src/middleware.rs#L141-L149>
+            // Clone the request so we can retry it on authentication failure
+            let retry_request = request.try_clone().ok_or_else(|| {
+                Error::Middleware(anyhow!(
+                    "Request object is not cloneable. Are you passing a streaming body?"
+                        .to_string()
+                ))
+            })?;
 
-        let response = next.clone().run(request, extensions).await?;
+            let response = next.clone().run(request, extensions).await?;
 
-        // If we don't fail with authorization related codes, return the response
-        if !matches!(
-            response.status(),
-            StatusCode::FORBIDDEN | StatusCode::NOT_FOUND | StatusCode::UNAUTHORIZED
-        ) {
-            return Ok(response);
-        }
+            // If we don't fail with authorization related codes, return the response
+            if !matches!(
+                response.status(),
+                StatusCode::FORBIDDEN | StatusCode::NOT_FOUND | StatusCode::UNAUTHORIZED
+            ) {
+                return Ok(response);
+            }
 
-        // Otherwise, search for credentials
-        trace!(
-            "Request for {url} failed with {}, checking for credentials",
-            response.status()
-        );
+            // Otherwise, search for credentials
+            trace!(
+                "Request for {url} failed with {}, checking for credentials",
+                response.status()
+            );
+
+            (retry_request, Some(response))
+        };
 
         // Check in the cache first
         let credentials = self.cache().get_realm(
@@ -265,7 +291,13 @@ impl Middleware for AuthMiddleware {
             }
         }
 
-        Ok(response)
+        if let Some(response) = response {
+            Ok(response)
+        } else {
+            Err(Error::Middleware(format_err!(
+                "Missing credentials for {url}"
+            )))
+        }
     }
 }
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -766,7 +766,7 @@ impl CacheBucket {
             Self::Interpreter => "interpreter-v2",
             // Note that when bumping this, you'll also need to bump it
             // in crates/uv/tests/cache_clean.rs.
-            Self::Simple => "simple-v12",
+            Self::Simple => "simple-v13",
             Self::Wheels => "wheels-v1",
             Self::Archive => "archive-v0",
             Self::Builds => "builds-v0",

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -10,6 +10,7 @@ use clap::{Args, Parser, Subcommand};
 use distribution_types::{FlatIndexLocation, IndexUrl};
 use pep508_rs::Requirement;
 use pypi_types::VerbatimParsedUrl;
+use url::Url;
 use uv_cache::CacheArgs;
 use uv_configuration::{
     ConfigSettingEntry, ExportFormat, IndexStrategy, KeyringProviderType, PackageNameSpecifier,
@@ -367,6 +368,8 @@ pub enum Commands {
         after_long_help = ""
     )]
     Build(BuildArgs),
+    /// Upload distributions to an index.
+    Publish(PublishArgs),
     /// Manage uv's cache.
     #[command(
         after_help = "Use `uv help cache` for more details.",
@@ -4286,4 +4289,66 @@ pub struct DisplayTreeArgs {
     /// Show the reverse dependencies for the given package. This flag will invert the tree and display the packages that depend on the given package.
     #[arg(long, alias = "reverse")]
     pub invert: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct PublishArgs {
+    /// The paths to the files to uploads, as glob expressions.
+    #[arg(default_value = "dist/*")]
+    pub files: Vec<String>,
+
+    /// The URL to the upload endpoint. Note: This is usually not the same as the index URL.
+    ///
+    /// The default value is publish URL for PyPI (<https://upload.pypi.org/legacy/>).
+    #[arg(long, env = "UV_PUBLISH_URL")]
+    pub publish_url: Option<Url>,
+
+    /// The username for the upload.
+    #[arg(short, long, env = "UV_PUBLISH_USERNAME")]
+    pub username: Option<String>,
+
+    /// The password for the upload.
+    #[arg(short, long, env = "UV_PUBLISH_PASSWORD")]
+    pub password: Option<String>,
+
+    /// The token for the upload.
+    ///
+    /// Using a token is equivalent to using `__token__` as username and using the token as
+    /// password.
+    #[arg(
+        short,
+        long,
+        env = "UV_PUBLISH_TOKEN",
+        conflicts_with = "username",
+        conflicts_with = "password"
+    )]
+    pub token: Option<String>,
+
+    /// Attempt to use `keyring` for authentication for remote requirements files.
+    ///
+    /// At present, only `--keyring-provider subprocess` is supported, which configures uv to
+    /// use the `keyring` CLI to handle authentication.
+    ///
+    /// Defaults to `disabled`.
+    #[arg(long, value_enum, env = "UV_KEYRING_PROVIDER")]
+    pub keyring_provider: Option<KeyringProviderType>,
+
+    /// Allow insecure connections to a host.
+    ///
+    /// Can be provided multiple times.
+    ///
+    /// Expects to receive either a hostname (e.g., `localhost`), a host-port pair (e.g.,
+    /// `localhost:8080`), or a URL (e.g., `https://localhost`).
+    ///
+    /// WARNING: Hosts included in this list will not be verified against the system's certificate
+    /// store. Only use `--allow-insecure-host` in a secure network with verified sources, as it
+    /// bypasses SSL verification and could expose you to MITM attacks.
+    #[arg(
+        long,
+        alias = "trusted-host",
+        env = "UV_INSECURE_HOST",
+        value_delimiter = ' ',
+        value_parser = parse_insecure_host,
+    )]
+    pub allow_insecure_host: Option<Vec<Maybe<TrustedHost>>>,
 }

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -27,6 +27,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 async_http_range_reader = { workspace = true }
 async_zip = { workspace = true }
+bytecheck = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 html-escape = { workspace = true }

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -36,6 +36,7 @@ pub struct BaseClientBuilder<'a> {
     client: Option<Client>,
     markers: Option<&'a MarkerEnvironment>,
     platform: Option<&'a Platform>,
+    only_authenticated: bool,
 }
 
 impl Default for BaseClientBuilder<'_> {
@@ -55,6 +56,7 @@ impl BaseClientBuilder<'_> {
             client: None,
             markers: None,
             platform: None,
+            only_authenticated: false,
         }
     }
 }
@@ -105,6 +107,12 @@ impl<'a> BaseClientBuilder<'a> {
     #[must_use]
     pub fn platform(mut self, platform: &'a Platform) -> Self {
         self.platform = Some(platform);
+        self
+    }
+
+    #[must_use]
+    pub fn only_authenticated(mut self, only_authenticated: bool) -> Self {
+        self.only_authenticated = only_authenticated;
         self
     }
 
@@ -230,20 +238,26 @@ impl<'a> BaseClientBuilder<'a> {
     fn apply_middleware(&self, client: Client) -> ClientWithMiddleware {
         match self.connectivity {
             Connectivity::Online => {
-                let client = reqwest_middleware::ClientBuilder::new(client);
+                let mut client = reqwest_middleware::ClientBuilder::new(client);
 
-                // Initialize the retry strategy.
-                let retry_policy =
-                    ExponentialBackoff::builder().build_with_max_retries(self.retries);
-                let retry_strategy = RetryTransientMiddleware::new_with_policy_and_strategy(
-                    retry_policy,
-                    UvRetryableStrategy,
-                );
-                let client = client.with(retry_strategy);
+                // Avoid non-cloneable errors with a streaming body during publish.
+                if self.retries > 0 {
+                    // Initialize the retry strategy.
+                    let retry_policy =
+                        ExponentialBackoff::builder().build_with_max_retries(self.retries);
+                    let retry_strategy = RetryTransientMiddleware::new_with_policy_and_strategy(
+                        retry_policy,
+                        UvRetryableStrategy,
+                    );
+                    client = client.with(retry_strategy);
+                }
 
                 // Initialize the authentication middleware to set headers.
-                let client =
-                    client.with(AuthMiddleware::new().with_keyring(self.keyring.to_provider()));
+                client = client.with(
+                    AuthMiddleware::new()
+                        .with_keyring(self.keyring.to_provider())
+                        .with_only_authenticated(self.only_authenticated),
+                );
 
                 client.build()
             }

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -75,9 +75,13 @@ impl<T: Serialize + DeserializeOwned> Cacheable for SerdeCacheable<T> {
 /// All `OwnedArchive` values are cacheable.
 impl<A> Cacheable for OwnedArchive<A>
 where
-    A: rkyv::Archive + rkyv::Serialize<crate::rkyvutil::Serializer<4096>>,
-    A::Archived: for<'a> rkyv::CheckBytes<rkyv::validation::validators::DefaultValidator<'a>>
-        + rkyv::Deserialize<A, rkyv::de::deserializers::SharedDeserializeMap>,
+    // A: rkyv::Archive + rkyv::Serialize<crate::rkyvutil::Serializer<4096>>,
+    // A::Archived: for<'a> rkyv::bytecheck::CheckBytes<rkyv::validation::validators::DefaultValidator<'a>>
+    // + rkyv::Deserialize<A, rkyv::de::deserializers::SharedDeserializeMap>,
+    A: rkyv::Archive + for<'a> rkyv::Serialize<crate::rkyvutil::Serializer<'a>>,
+    A::Archived: rkyv::Portable
+        + rkyv::Deserialize<A, crate::rkyvutil::Deserializer>
+        + for<'a> rkyv::bytecheck::CheckBytes<crate::rkyvutil::Validator<'a>>,
 {
     type Target = Self;
 

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -227,7 +227,7 @@ pub enum ErrorKind {
     ArchiveRead(String),
 
     #[error("Writing to cache archive failed: {0}")]
-    ArchiveWrite(#[source] crate::rkyvutil::SerializerError),
+    ArchiveWrite(String),
 
     #[error("Network connectivity is disabled, but the requested data wasn't found in the cache for: `{0}`")]
     Offline(String),

--- a/crates/uv-client/src/httpcache/control.rs
+++ b/crates/uv-client/src/httpcache/control.rs
@@ -20,8 +20,7 @@ use crate::rkyvutil::OwnedArchive;
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 #[allow(clippy::struct_excessive_bools)]
 pub struct CacheControl {
     // directives for requests and responses

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -137,7 +137,7 @@ actually need to make an HTTP request).
 
 use std::time::{Duration, SystemTime};
 
-use {http::header::HeaderValue, rkyv::bytecheck};
+use http::header::HeaderValue;
 
 use crate::rkyvutil::OwnedArchive;
 
@@ -151,12 +151,19 @@ mod control;
 /// suspect we won't ever need to. We split them out into their own type so
 /// that they can be shared between `CachePolicyBuilder` and `CachePolicy`.
 #[derive(
-    Clone, Debug, Default, rkyv::Archive, rkyv::CheckBytes, rkyv::Deserialize, rkyv::Serialize,
+    Clone,
+    Debug,
+    Default,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Portable,
+    rkyv::Serialize,
+    bytecheck::CheckBytes,
 )]
 // Since `CacheConfig` is so simple, we can use itself as the archived type.
 // But note that this will fall apart if even something like an Option<u8> is
 // added.
-#[archive(as = "Self")]
+#[rkyv(as = Self)]
 #[repr(C)]
 struct CacheConfig {
     shared: bool,
@@ -232,8 +239,7 @@ impl CachePolicyBuilder {
 /// absent from this (among other things that uv probably doesn't care
 /// about it) are proxy cache semantics.
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct CachePolicy {
     /// The configuration controlling the behavior of the cache.
     config: CacheConfig,
@@ -393,7 +399,7 @@ impl ArchivedCachePolicy {
         if self.is_modified(&new_policy) {
             AfterResponse::Modified(new_policy)
         } else {
-            new_policy.response.status = self.response.status;
+            new_policy.response.status = self.response.status.into();
             AfterResponse::NotModified(new_policy)
         }
     }
@@ -522,7 +528,8 @@ impl ArchivedCachePolicy {
             if let Some(&last_modified_unix_timestamp) =
                 self.response.headers.last_modified_unix_timestamp.as_ref()
             {
-                if let Some(last_modified) = unix_timestamp_to_header(last_modified_unix_timestamp)
+                if let Some(last_modified) =
+                    unix_timestamp_to_header(last_modified_unix_timestamp.into())
                 {
                     request
                         .headers_mut()
@@ -696,7 +703,7 @@ impl ArchivedCachePolicy {
         // ... we don't support any extensions.
         //
         // "a status code that is defined as heuristically cacheable"
-        if HEURISTICALLY_CACHEABLE_STATUS_CODES.contains(&self.response.status) {
+        if HEURISTICALLY_CACHEABLE_STATUS_CODES.contains(&self.response.status.into()) {
             tracing::trace!(
                 "cached request {} is storable because its response has a \
                  heuristically cacheable status code {:?}",
@@ -856,7 +863,7 @@ impl ArchivedCachePolicy {
                 .age(now)
                 .as_secs()
                 .saturating_sub(self.freshness_lifetime().as_secs());
-            if stale_amount <= max_stale {
+            if stale_amount <= max_stale.into() {
                 tracing::trace!(
                     "cached request {} has a cached response that allows staleness \
                      in this case because the stale amount is {} seconds and the \
@@ -894,17 +901,13 @@ impl ArchivedCachePolicy {
     /// [RFC 9111 S4.2.3]: https://www.rfc-editor.org/rfc/rfc9111.html#name-calculating-age
     fn age(&self, now: SystemTime) -> Duration {
         // RFC 9111 S4.2.3
-        let apparent_age = self
-            .response
-            .unix_timestamp
-            .saturating_sub(self.response.header_date());
-        let response_delay = self
-            .response
-            .unix_timestamp
-            .saturating_sub(self.request.unix_timestamp);
+        let apparent_age =
+            u64::from(self.response.unix_timestamp).saturating_sub(self.response.header_date());
+        let response_delay = u64::from(self.response.unix_timestamp)
+            .saturating_sub(self.request.unix_timestamp.into());
         let corrected_age_value = self.response.header_age().saturating_add(response_delay);
         let corrected_initial_age = apparent_age.max(corrected_age_value);
-        let resident_age = unix_timestamp(now).saturating_sub(self.response.unix_timestamp);
+        let resident_age = unix_timestamp(now).saturating_sub(self.response.unix_timestamp.into());
         let current_age = corrected_initial_age + resident_age;
         Duration::from_secs(current_age)
     }
@@ -921,7 +924,7 @@ impl ArchivedCachePolicy {
     fn freshness_lifetime(&self) -> Duration {
         if self.config.shared {
             if let Some(&s_maxage) = self.response.headers.cc.s_maxage_seconds.as_ref() {
-                let duration = Duration::from_secs(s_maxage);
+                let duration = Duration::from_secs(s_maxage.into());
                 tracing::trace!(
                     "freshness lifetime found via shared \
                      cache-control max age setting: {duration:?}"
@@ -930,14 +933,15 @@ impl ArchivedCachePolicy {
             }
         }
         if let Some(&max_age) = self.response.headers.cc.max_age_seconds.as_ref() {
-            let duration = Duration::from_secs(max_age);
+            let duration = Duration::from_secs(max_age.into());
             tracing::trace!(
                 "freshness lifetime found via cache-control max age setting: {duration:?}"
             );
             return duration;
         }
         if let Some(&expires) = self.response.headers.expires_unix_timestamp.as_ref() {
-            let duration = Duration::from_secs(expires.saturating_sub(self.response.header_date()));
+            let duration =
+                Duration::from_secs(u64::from(expires).saturating_sub(self.response.header_date()));
             tracing::trace!("freshness lifetime found via expires header: {duration:?}");
             return duration;
         }
@@ -1019,8 +1023,7 @@ pub enum AfterResponse {
 }
 
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 struct Request {
     uri: String,
     method: Method,
@@ -1040,8 +1043,7 @@ impl<'a> From<&'a reqwest::Request> for Request {
 }
 
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 struct RequestHeaders {
     /// The cache control directives from the `Cache-Control` header.
     cc: CacheControl,
@@ -1065,8 +1067,7 @@ impl<'a> From<&'a http::HeaderMap> for RequestHeaders {
 /// cache. Instead, we treat them as "unrecognized" and consider the responses
 /// not-storable.
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 #[repr(u8)]
 enum Method {
     Get,
@@ -1087,8 +1088,7 @@ impl<'a> From<&'a http::Method> for Method {
 }
 
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 struct Response {
     status: u16,
     headers: ResponseHeaders,
@@ -1105,7 +1105,11 @@ impl ArchivedResponse {
     ///
     /// [RFC 9111 S4.2.3]: https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.3
     fn header_age(&self) -> u64 {
-        self.headers.age_seconds.unwrap_or(0)
+        self.headers
+            .age_seconds
+            .as_ref()
+            .map(u64::from)
+            .unwrap_or(0)
     }
 
     /// Returns the "date" header value on this response, with a fallback to
@@ -1116,6 +1120,7 @@ impl ArchivedResponse {
         self.headers
             .date_unix_timestamp
             .unwrap_or(self.unix_timestamp)
+            .into()
     }
 
     /// Returns true when this response has a status code that is considered
@@ -1138,8 +1143,7 @@ impl<'a> From<&'a reqwest::Response> for Response {
 }
 
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 struct ResponseHeaders {
     /// The directives from the `Cache-Control` header.
     cc: CacheControl,
@@ -1209,8 +1213,7 @@ impl<'a> From<&'a http::HeaderMap> for ResponseHeaders {
 }
 
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 struct ETag {
     /// The actual `ETag` validator value.
     ///
@@ -1267,8 +1270,7 @@ impl ETag {
 /// [RFC 9110 S12.5.5]: https://www.rfc-editor.org/rfc/rfc9110#section-12.5.5
 /// [RFC 9111 S4.1]: https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 struct Vary {
     fields: Vec<VaryField>,
 }
@@ -1349,8 +1351,7 @@ impl ArchivedVary {
 ///
 /// [RFC 9111 S4.1]: https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1
 #[derive(Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 struct VaryField {
     name: String,
     value: Vec<u8>,

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -7,7 +7,7 @@ pub use registry_client::{
     Connectivity, RegistryClient, RegistryClientBuilder, SimpleMetadata, SimpleMetadatum,
     VersionFiles,
 };
-pub use rkyvutil::OwnedArchive;
+pub use rkyvutil::{Deserializer, OwnedArchive, Serializer, Validator};
 
 mod base_client;
 mod cached_client;

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -725,8 +725,7 @@ impl RegistryClient {
 #[derive(
     Default, Debug, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct VersionFiles {
     pub wheels: Vec<VersionWheel>,
     pub source_dists: Vec<VersionSourceDist>,
@@ -757,16 +756,14 @@ impl VersionFiles {
 }
 
 #[derive(Debug, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct VersionWheel {
     pub name: WheelFilename,
     pub file: File,
 }
 
 #[derive(Debug, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct VersionSourceDist {
     pub name: SourceDistFilename,
     pub file: File,
@@ -775,13 +772,11 @@ pub struct VersionSourceDist {
 #[derive(
     Default, Debug, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
 )]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct SimpleMetadata(Vec<SimpleMetadatum>);
 
 #[derive(Debug, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct SimpleMetadatum {
     pub version: Version,
     pub files: VersionFiles,

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -88,20 +88,20 @@ impl LoweredRequirement {
                 if matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_))) {
                     return Err(LoweringError::ConflictingUrls);
                 }
-                git_source(&git, subdirectory, rev, tag, branch)?
+                git_source(&git, subdirectory.map(PathBuf::from), rev, tag, branch)?
             }
             Source::Url { url, subdirectory } => {
                 if matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_))) {
                     return Err(LoweringError::ConflictingUrls);
                 }
-                url_source(url, subdirectory)?
+                url_source(url, subdirectory.map(PathBuf::from))?
             }
             Source::Path { path, editable } => {
                 if matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_))) {
                     return Err(LoweringError::ConflictingUrls);
                 }
                 path_source(
-                    path,
+                    PathBuf::from(path),
                     origin,
                     project_dir,
                     workspace.install_path(),
@@ -203,19 +203,25 @@ impl LoweredRequirement {
                 if matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_))) {
                     return Err(LoweringError::ConflictingUrls);
                 }
-                git_source(&git, subdirectory, rev, tag, branch)?
+                git_source(&git, subdirectory.map(PathBuf::from), rev, tag, branch)?
             }
             Source::Url { url, subdirectory } => {
                 if matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_))) {
                     return Err(LoweringError::ConflictingUrls);
                 }
-                url_source(url, subdirectory)?
+                url_source(url, subdirectory.map(PathBuf::from))?
             }
             Source::Path { path, editable } => {
                 if matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_))) {
                     return Err(LoweringError::ConflictingUrls);
                 }
-                path_source(path, Origin::Project, dir, dir, editable.unwrap_or(false))?
+                path_source(
+                    PathBuf::from(path),
+                    Origin::Project,
+                    dir,
+                    dir,
+                    editable.unwrap_or(false),
+                )?
             }
             Source::Registry { index } => registry_source(&requirement, index)?,
             Source::Workspace { .. } => {

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -13,7 +13,6 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-uv-warnings = { workspace = true }
 
 backoff = { workspace = true }
 cachedir = { workspace = true }

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -22,6 +22,7 @@ encoding_rs_io = { workspace = true }
 fs-err = { workspace = true }
 fs2 = { workspace = true }
 path-slash = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true}
 tempfile = { workspace = true }

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -2,9 +2,7 @@ use fs2::FileExt;
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
-use tracing::{debug, error, trace, warn};
-
-use uv_warnings::warn_user;
+use tracing::{debug, error, info, trace, warn};
 
 pub use crate::path::*;
 
@@ -329,8 +327,8 @@ impl LockedFile {
                 // Log error code and enum kind to help debugging more exotic failures
                 // TODO(zanieb): When `raw_os_error` stabilizes, use that to avoid displaying
                 // the error when it is `WouldBlock`, which is expected and noisy otherwise.
-                trace!("Try lock error, waiting for exclusive lock: {:?}", err);
-                warn_user!(
+                trace!("Try lock error: {err:?}");
+                info!(
                     "Waiting to acquire lock for `{resource}` at `{}`",
                     file.path().user_display(),
                 );

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -301,6 +301,17 @@ pub struct PortablePath<'a>(&'a Path);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PortablePathBuf(PathBuf);
 
+#[cfg(feature = "schemars")]
+impl schemars::JsonSchema for PortablePathBuf {
+    fn schema_name() -> String {
+        PathBuf::schema_name()
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        PathBuf::json_schema(_gen)
+    }
+}
+
 impl AsRef<Path> for PortablePath<'_> {
     fn as_ref(&self) -> &Path {
         self.0

--- a/crates/uv-normalize/src/package_name.rs
+++ b/crates/uv-normalize/src/package_name.rs
@@ -26,8 +26,7 @@ use crate::{validate_and_normalize_owned, validate_and_normalize_ref, InvalidNam
     rkyv::Serialize,
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[rkyv(derive(Debug))]
 pub struct PackageName(String);
 
 impl PackageName {

--- a/crates/uv-publish/Cargo.toml
+++ b/crates/uv-publish/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "uv-publish"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+distribution-filename = { workspace = true }
+uv-client = { workspace = true }
+uv-fs = { workspace = true }
+uv-metadata = { workspace = true }
+uv-warnings = { workspace = true }
+
+async-compression = { workspace = true }
+base64 = { workspace = true }
+fs-err = { workspace = true }
+futures = { workspace = true }
+glob = { workspace = true }
+itertools = { workspace = true }
+krata-tokio-tar = { workspace = true }
+python-pkginfo = { workspace = true }
+reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
+
+[dev-dependencies]
+insta = { version = "1.36.1", features = ["json", "filters"] }
+
+[lints]
+workspace = true

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1,0 +1,789 @@
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
+use distribution_filename::{DistFilename, SourceDistExtension, SourceDistFilename};
+use fs_err::File;
+use futures::TryStreamExt;
+use glob::{glob, GlobError, PatternError};
+use itertools::Itertools;
+use python_pkginfo::Metadata;
+use reqwest::header::AUTHORIZATION;
+use reqwest::multipart::Part;
+use reqwest::{Body, Response, StatusCode};
+use reqwest_middleware::RequestBuilder;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::{fmt, io};
+use thiserror::Error;
+use tokio::io::AsyncReadExt;
+use tracing::{debug, enabled, trace, Level};
+use url::Url;
+use uv_client::BaseClient;
+use uv_fs::Simplified;
+use uv_metadata::read_metadata_async_seek;
+use uv_warnings::warn_user_once;
+
+#[derive(Error, Debug)]
+pub enum PublishError {
+    #[error("Invalid publish paths")]
+    Pattern(#[from] PatternError),
+    /// [`GlobError`] is a wrapped io error.
+    #[error(transparent)]
+    Glob(#[from] GlobError),
+    #[error("Path patterns didn't match any wheels or source distributions")]
+    NoFiles,
+    #[error(transparent)]
+    Fmt(#[from] fmt::Error),
+    #[error("File is neither a wheel nor a source distribution: `{}`", _0.user_display())]
+    InvalidFilename(PathBuf),
+    #[error("Failed to publish: `{}`", _0.user_display())]
+    PublishPrepare(PathBuf, #[source] PublishPrepareError),
+    #[error("Failed to publish `{}` to `{}`", _0.user_display(), _1)]
+    PublishSend(PathBuf, Url, #[source] PublishSendError),
+}
+
+/// Failure to get the metadata for a specific file.
+#[derive(Error, Debug)]
+pub enum PublishPrepareError {
+    #[error(transparent)]
+    PkgInfoError(#[from] python_pkginfo::Error),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error("Failed to read metadata")]
+    Metadata(#[from] uv_metadata::Error),
+    #[error("Only files ending in `.tar.gz` are valid source distributions: `{0}`")]
+    InvalidExtension(SourceDistFilename),
+    #[error("No PKG-INFO file found")]
+    MissingPkgInfo,
+    #[error("Multiple PKG-INFO files found: `{0}`")]
+    MultiplePkgInfo(String),
+    #[error("Failed to read: `{0}`")]
+    Read(String, #[source] io::Error),
+}
+
+/// Failure in or after (HTTP) transport for a specific file.
+#[derive(Error, Debug)]
+pub enum PublishSendError {
+    #[error("Failed to send POST request: `{0}`")]
+    ReqwestMiddleware(Url, #[source] reqwest_middleware::Error),
+    #[error("Upload failed with status {0}")]
+    StatusNoBody(StatusCode, #[source] reqwest::Error),
+    #[error("Upload failed with status code {0}: {1}")]
+    Status(StatusCode, String),
+    /// The registry returned a "403 Forbidden"
+    #[error("Incorrect credentials (status code {0}): {1}")]
+    IncorrectCredentials(StatusCode, String),
+}
+
+impl PublishSendError {
+    /// Extract `code` from the PyPI json error response, if any.
+    ///
+    /// The error response from PyPI contains crucial context, such as the difference between
+    /// "Invalid or non-existent authentication information" and "The user 'konstin' isn't allowed
+    /// to upload to project 'dummy'".
+    ///
+    /// Twine uses the HTTP status reason for its error messages. In HTTP 2.0 and onward this field
+    /// is abolished, so reqwest doesn't expose it, see
+    /// <https://docs.rs/reqwest/0.12.7/reqwest/struct.StatusCode.html#method.canonical_reason>.
+    /// PyPI does respect the content type for error responses and can return an error display as
+    /// HTML, JSON and plain. Since HTML and plain text are both overly verbose, we show the JSON
+    /// response. Examples are shown below, line breaks were inserted for readability. Of those,
+    /// the `code` seems to be the most helpful message, so we return it. If the response isn't a
+    /// JSON document with `code` we return the regular body
+    ///
+    /// ```json
+    /// {"message": "The server could not comply with the request since it is either malformed or
+    /// otherwise incorrect.\n\n\nError: Use 'source' as Python version for an sdist.\n\n",
+    /// "code": "400 Error: Use 'source' as Python version for an sdist.",
+    /// "title": "Bad Request"}
+    /// ```
+    ///
+    /// ```json
+    /// {"message": "Access was denied to this resource.\n\n\nInvalid or non-existent authentication
+    /// information. See https://test.pypi.org/help/#invalid-auth for more information.\n\n",
+    /// "code": "403 Invalid or non-existent authentication information. See
+    /// https://test.pypi.org/help/#invalid-auth for more information.",
+    /// "title": "Forbidden"}
+    /// ```
+    /// ```json
+    /// {"message": "Access was denied to this resource.\n\n\n\n\n",
+    /// "code": "403 Username/Password authentication is no longer supported. Migrate to API
+    /// Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and
+    /// https://test.pypi.org/help/#trusted-publishers",
+    /// "title": "Forbidden"}
+    /// ```
+    ///
+    /// For context, for the last case twine shows:
+    /// ```text
+    /// WARNING  Error during upload. Retry with the --verbose option for more details.
+    /// ERROR    HTTPError: 403 Forbidden from https://test.pypi.org/legacy/
+    ///          Username/Password authentication is no longer supported. Migrate to API
+    ///          Tokens or Trusted Publishers instead. See
+    ///          https://test.pypi.org/help/#apitoken and
+    ///          https://test.pypi.org/help/#trusted-publishers
+    /// ```
+    ///
+    /// ```text
+    /// INFO     Response from https://test.pypi.org/legacy/:
+    ///          403 Username/Password authentication is no longer supported. Migrate to
+    ///          API Tokens or Trusted Publishers instead. See
+    ///          https://test.pypi.org/help/#apitoken and
+    ///          https://test.pypi.org/help/#trusted-publishers
+    /// INFO     <html>
+    ///           <head>
+    ///            <title>403 Username/Password authentication is no longer supported.
+    ///          Migrate to API Tokens or Trusted Publishers instead. See
+    ///          https://test.pypi.org/help/#apitoken and
+    ///          https://test.pypi.org/help/#trusted-publishers</title>
+    ///           </head>
+    ///          <body>
+    ///           <h1>403 Username/Password authentication is no longer supported.
+    ///         Migrate to API Tokens or Trusted Publishers instead. See
+    ///          https://test.pypi.org/help/#apitoken and
+    ///          https://test.pypi.org/help/#trusted-publishers</h1>
+    ///            Access was denied to this resource.<br/><br/>
+    /// ```
+    ///
+    /// In comparison, we now show (line-wrapped for readability):
+    ///
+    /// ```text
+    /// error: Failed to publish `dist/astral_test_1-0.1.0-py3-none-any.whl` to `https://test.pypi.org/legacy/`
+    ///   Caused by: Incorrect credentials (status code 403 Forbidden): 403 Username/Password
+    ///     authentication is no longer supported. Migrate to API Tokens or Trusted Publishers
+    ///     instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+    /// ```
+    fn extract_error_message(body: String, content_type: Option<&str>) -> String {
+        if content_type == Some("application/json") {
+            #[derive(Deserialize)]
+            struct ErrorBody {
+                code: String,
+            }
+
+            if let Ok(structured) = serde_json::from_str::<ErrorBody>(&body) {
+                structured.code
+            } else {
+                body
+            }
+        } else {
+            body
+        }
+    }
+}
+
+pub fn files_for_publishing(
+    paths: Vec<String>,
+) -> Result<Vec<(PathBuf, DistFilename)>, PublishError> {
+    let mut seen = HashSet::new();
+    let mut files = Vec::new();
+    for path in paths {
+        for entry in glob(&path)? {
+            let entry = entry?;
+            if !seen.insert(entry.clone()) {
+                continue;
+            }
+            if !entry.is_file() {
+                continue;
+            }
+            let Some(filename) = entry.file_name().and_then(|filename| filename.to_str()) else {
+                continue;
+            };
+            let filename = DistFilename::try_from_normalized_filename(filename)
+                .ok_or_else(|| PublishError::InvalidFilename(entry.clone()))?;
+            files.push((entry, filename));
+        }
+    }
+    // TODO(konsti): Should we sort those files, e.g. wheels before sdists because they are more
+    // certain to have reliable metadata, even though the metadata in the upload API is unreliable
+    // in general?
+    Ok(files)
+}
+
+/// Calculate the SHA256 of a file.
+fn hash_file(path: impl AsRef<Path>) -> Result<String, io::Error> {
+    // Ideally, this would be async, but in case we actually want to make parallel uploads we should
+    // use `spawn_blocking` since sha256 is cpu intensive.
+    let mut file = BufReader::new(File::open(path.as_ref())?);
+    let mut hasher = Sha256::new();
+    io::copy(&mut file, &mut hasher)?;
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+// Not in `uv-metadata` because we only support tar files here.
+async fn source_dist_pkg_info(file: &Path) -> Result<Vec<u8>, PublishPrepareError> {
+    let file = fs_err::tokio::File::open(&file).await?;
+    let reader = tokio::io::BufReader::new(file);
+    let decoded = async_compression::tokio::bufread::GzipDecoder::new(reader);
+    let mut archive = tokio_tar::Archive::new(decoded);
+    let mut pkg_infos: Vec<(PathBuf, Vec<u8>)> = archive
+        .entries()?
+        .map_err(PublishPrepareError::from)
+        .try_filter_map(|mut entry| async move {
+            let path = entry
+                .path()
+                .map_err(PublishPrepareError::from)?
+                .to_path_buf();
+            let mut components = path.components();
+            let Some(_top_level) = components.next() else {
+                return Ok(None);
+            };
+            let Some(pkg_info) = components.next() else {
+                return Ok(None);
+            };
+            if components.next().is_some() || pkg_info.as_os_str() != "PKG-INFO" {
+                return Ok(None);
+            }
+            let mut buffer = Vec::new();
+            entry.read_to_end(&mut buffer).await.map_err(|err| {
+                PublishPrepareError::Read(path.to_string_lossy().to_string(), err)
+            })?;
+            Ok(Some((path, buffer)))
+        })
+        .try_collect()
+        .await?;
+    match pkg_infos.len() {
+        0 => Err(PublishPrepareError::MissingPkgInfo),
+        1 => Ok(pkg_infos.remove(0).1),
+        _ => Err(PublishPrepareError::MultiplePkgInfo(
+            pkg_infos
+                .iter()
+                .map(|(path, _buffer)| path.to_string_lossy())
+                .join(", "),
+        )),
+    }
+}
+
+async fn metadata(file: &Path, filename: &DistFilename) -> Result<Metadata, PublishPrepareError> {
+    let contents = match filename {
+        DistFilename::SourceDistFilename(source_dist) => {
+            if source_dist.extension != SourceDistExtension::TarGz {
+                // See PEP 625. While we support installing legacy source distributions, we don't
+                // support creating and uploading them.
+                return Err(PublishPrepareError::InvalidExtension(source_dist.clone()));
+            }
+            source_dist_pkg_info(file).await?
+        }
+        DistFilename::WheelFilename(wheel) => {
+            let file = fs_err::tokio::File::open(&file).await?;
+            let reader = tokio::io::BufReader::new(file);
+            read_metadata_async_seek(wheel, reader).await?
+        }
+    };
+    Ok(Metadata::parse(&contents)?)
+}
+
+/// Upload a file to a registry.
+///
+/// Returns `true` if the file was newly uploaded and `false` if it already existed.
+pub async fn upload(
+    file: &Path,
+    filename: &DistFilename,
+    registry: &Url,
+    client: &BaseClient,
+    username: Option<&str>,
+    password: Option<&str>,
+) -> Result<bool, PublishError> {
+    let form_metadata = form_metadata(file, filename)
+        .await
+        .map_err(|err| PublishError::PublishPrepare(file.to_path_buf(), err))?;
+    let request = build_request(
+        file,
+        filename,
+        registry,
+        client,
+        username,
+        password,
+        form_metadata,
+    )
+    .await
+    .map_err(|err| PublishError::PublishPrepare(file.to_path_buf(), err))?;
+
+    let response = request.send().await.map_err(|err| {
+        let send_err = PublishSendError::ReqwestMiddleware(registry.clone(), err);
+        PublishError::PublishSend(file.to_path_buf(), registry.clone(), send_err)
+    })?;
+
+    handle_response(registry, response)
+        .await
+        .map_err(|err| PublishError::PublishSend(file.to_path_buf(), registry.clone(), err))
+}
+
+/// Collect the non-file field for the multipart request from the package METADATA.
+async fn form_metadata(
+    file: &Path,
+    filename: &DistFilename,
+) -> Result<Vec<(&'static str, String)>, PublishPrepareError> {
+    let hash_hex = hash_file(file)?;
+
+    let metadata = metadata(file, filename).await?;
+
+    let mut form_metadata = vec![
+        (":action", "file_upload".to_string()),
+        ("sha256_digest", hash_hex),
+        ("protocol_version", "1".to_string()),
+        ("metadata_version", metadata.metadata_version.clone()),
+        // Twine transforms the name with `re.sub("[^A-Za-z0-9.]+", "-", name)`
+        // * <https://github.com/pypa/twine/issues/743>
+        // * <https://github.com/pypa/twine/blob/5bf3f38ff3d8b2de47b7baa7b652c697d7a64776/twine/package.py#L57-L65>
+        // warehouse seems to call `packaging.utils.canonicalize_name` nowadays and has a separate
+        // `normalized_name`, so we'll start with this and we'll readjust if there are user reports.
+        ("name", metadata.name.clone()),
+        ("version", metadata.version.clone()),
+        ("filetype", filename.filetype().to_string()),
+    ];
+
+    if let DistFilename::WheelFilename(wheel) = filename {
+        form_metadata.push(("pyversion", wheel.python_tag.join(".")));
+    } else {
+        form_metadata.push(("pyversion", "source".to_string()));
+    }
+
+    let mut add_option = |name, value: Option<String>| {
+        if let Some(some) = value.clone() {
+            form_metadata.push((name, some));
+        }
+    };
+
+    // https://github.com/pypi/warehouse/blob/d2c36d992cf9168e0518201d998b2707a3ef1e72/warehouse/forklift/legacy.py#L1376-L1430
+    add_option("summary", metadata.summary);
+    add_option("description", metadata.description);
+    add_option(
+        "description_content_type",
+        metadata.description_content_type,
+    );
+    add_option("author", metadata.author);
+    add_option("author_email", metadata.author_email);
+    add_option("maintainer", metadata.maintainer);
+    add_option("maintainer_email", metadata.maintainer_email);
+    add_option("license", metadata.license);
+    add_option("keywords", metadata.keywords);
+    add_option("home_page", metadata.home_page);
+    add_option("download_url", metadata.download_url);
+
+    // GitLab PyPI repository API implementation requires this metadata field
+    // and twine always includes it in the request, even when it's empty.
+    form_metadata.push((
+        "requires_python",
+        metadata.requires_python.unwrap_or(String::new()),
+    ));
+
+    let mut add_vec = |name, values: Vec<String>| {
+        for i in values {
+            form_metadata.push((name, i.clone()));
+        }
+    };
+
+    add_vec("classifiers", metadata.classifiers);
+    add_vec("platform", metadata.platforms);
+    add_vec("requires_dist", metadata.requires_dist);
+    add_vec("provides_dist", metadata.provides_dist);
+    add_vec("obsoletes_dist", metadata.obsoletes_dist);
+    add_vec("requires_external", metadata.requires_external);
+    add_vec("project_urls", metadata.project_urls);
+
+    Ok(form_metadata)
+}
+
+async fn build_request(
+    file: &Path,
+    filename: &DistFilename,
+    registry: &Url,
+    client: &BaseClient,
+    username: Option<&str>,
+    password: Option<&str>,
+    form_metadata: Vec<(&'static str, String)>,
+) -> Result<RequestBuilder, PublishPrepareError> {
+    let mut form = reqwest::multipart::Form::new();
+    for (key, value) in form_metadata {
+        form = form.text(key, value);
+    }
+
+    let file: tokio::fs::File = fs_err::tokio::File::open(file).await?.into();
+    let file_reader = Body::from(file);
+    form = form.part(
+        "content",
+        Part::stream(file_reader).file_name(filename.to_string()),
+    );
+
+    let url = if let Some(username) = username {
+        if password.is_none() {
+            // Attach the username to the URL so the authentication middleware can find the matching
+            // password.
+            let mut url = registry.clone();
+            let _ = url.set_username(username);
+            url
+        } else {
+            // We set the authorization header below.
+            registry.clone()
+        }
+    } else {
+        registry.clone()
+    };
+
+    let mut request = client
+        .client()
+        .post(url)
+        .multipart(form)
+        // Ask PyPI for a structured error messages instead of HTML-markup error messages.
+        // For other registries, we ask them to return plain text over HTML. See
+        // [`PublishSendError::extract_remote_error`].
+        .header(
+            reqwest::header::ACCEPT,
+            "application/json;q=0.9, text/plain;q=0.8, text/html;q=0.7",
+        );
+    if let (Some(username), Some(password)) = (username, password) {
+        debug!("Using username/password basic auth");
+        let credentials = BASE64_STANDARD.encode(format!("{username}:{password}"));
+        request = request.header(AUTHORIZATION, format!("Basic {credentials}"));
+    }
+    Ok(request)
+}
+
+/// Returns `true` if the file was newly uploaded and `false` if it already existed.
+async fn handle_response(registry: &Url, response: Response) -> Result<bool, PublishSendError> {
+    let status_code = response.status();
+    debug!("Response code for {registry}: {status_code}");
+    trace!("Response headers for {registry}: {response:?}");
+
+    // TODO(konsti): There's some strange behavior here we're not handling yet: When I POST to
+    // https://test.pypi.org/simple/, I get a method not allowed error (as it should be), but when
+    // I post to https://test.pypi.org/simple (no slash) it returns a 200 with the content of the
+    // index that you should only GET. Logs for the latter case:
+    // ```text
+    // DEBUG redirecting 'https://test.pypi.org/simple' to 'https://test.pypi.org/simple/'
+    // DEBUG reuse idle connection for ("https", test.pypi.org)
+    // DEBUG Response code for https://test.pypi.org/simple: 200 OK
+    // TRACE Response headers for https://test.pypi.org/simple: Response { url: "https://test.pypi.org/simple/", [...] }
+    // ```
+    // twine always errors on redirects (<https://github.com/pypa/twine/commit/29e85757559154e919c9fe0a7f5803a425628855>),
+    // which does not seem desirable either.
+    if response.url() != registry {
+        warn_user_once!(
+            "The request was redirected, please use the new URL for future requests: {}",
+            response.url()
+        );
+    }
+
+    if status_code.is_success() {
+        if enabled!(Level::TRACE) {
+            match response.text().await {
+                Ok(response_content) => {
+                    trace!("Response content for {registry}: {response_content}");
+                }
+                Err(err) => {
+                    trace!("Failed to read response content for {registry}: {err}");
+                }
+            }
+        }
+        return Ok(true);
+    }
+
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|content_type| content_type.to_str().ok())
+        .map(ToString::to_string);
+    let upload_error = response
+        .bytes()
+        .await
+        .map_err(|err| PublishSendError::StatusNoBody(status_code, err))?;
+    let upload_error = String::from_utf8_lossy(&upload_error);
+
+    trace!("Response content for non-200 for {registry}: {upload_error}");
+
+    debug!("Upload error response: {upload_error}");
+    // Detect existing file errors the way twine does.
+    // https://github.com/pypa/twine/blob/c512bbf166ac38239e58545a39155285f8747a7b/twine/commands/upload.py#L34-L72
+    if status_code == 403 {
+        if upload_error.contains("overwrite artifact") {
+            // Artifactory (https://jfrog.com/artifactory/)
+            Ok(false)
+        } else {
+            Err(PublishSendError::IncorrectCredentials(
+                status_code,
+                PublishSendError::extract_error_message(
+                    upload_error.to_string(),
+                    content_type.as_deref(),
+                ),
+            ))
+        }
+    } else if status_code == 409 {
+        // conflict, pypiserver (https://pypi.org/project/pypiserver)
+        Ok(false)
+    } else if status_code == 400
+        && (upload_error.contains("updating asset") || upload_error.contains("already been taken"))
+    {
+        // Nexus Repository OSS (https://www.sonatype.com/nexus-repository-oss)
+        // and Gitlab Enterprise Edition (https://about.gitlab.com)
+        Ok(false)
+    } else {
+        Err(PublishSendError::Status(
+            status_code,
+            PublishSendError::extract_error_message(
+                upload_error.to_string(),
+                content_type.as_deref(),
+            ),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{build_request, form_metadata};
+    use distribution_filename::DistFilename;
+    use insta::{assert_debug_snapshot, assert_snapshot};
+    use itertools::Itertools;
+    use std::path::PathBuf;
+    use url::Url;
+    use uv_client::BaseClientBuilder;
+
+    /// Snapshot the data we send for an upload request for a source distribution.
+    #[tokio::test]
+    async fn upload_request_source_dist() {
+        let filename = "tqdm-999.0.0.tar.gz";
+        let file = PathBuf::from("../../scripts/links/").join(filename);
+        let filename = DistFilename::try_from_normalized_filename(filename).unwrap();
+
+        let form_metadata = form_metadata(&file, &filename).await.unwrap();
+
+        let formatted_metadata = form_metadata
+            .iter()
+            .map(|(k, v)| format!("{k}: {v}"))
+            .join("\n");
+        assert_snapshot!(&formatted_metadata, @r###"
+        :action: file_upload
+        sha256_digest: 89fa05cffa7f457658373b85de302d24d0c205ceda2819a8739e324b75e9430b
+        protocol_version: 1
+        metadata_version: 2.3
+        name: tqdm
+        version: 999.0.0
+        filetype: sdist
+        pyversion: source
+        description: # tqdm
+
+        [![PyPI - Version](https://img.shields.io/pypi/v/tqdm.svg)](https://pypi.org/project/tqdm)
+        [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/tqdm.svg)](https://pypi.org/project/tqdm)
+
+        -----
+
+        **Table of Contents**
+
+        - [Installation](#installation)
+        - [License](#license)
+
+        ## Installation
+
+        ```console
+        pip install tqdm
+        ```
+
+        ## License
+
+        `tqdm` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.
+
+        description_content_type: text/markdown
+        author_email: Charlie Marsh <charlie.r.marsh@gmail.com>
+        requires_python: >=3.8
+        classifiers: Development Status :: 4 - Beta
+        classifiers: Programming Language :: Python
+        classifiers: Programming Language :: Python :: 3.8
+        classifiers: Programming Language :: Python :: 3.9
+        classifiers: Programming Language :: Python :: 3.10
+        classifiers: Programming Language :: Python :: 3.11
+        classifiers: Programming Language :: Python :: 3.12
+        classifiers: Programming Language :: Python :: Implementation :: CPython
+        classifiers: Programming Language :: Python :: Implementation :: PyPy
+        project_urls: Documentation, https://github.com/unknown/tqdm#readme
+        project_urls: Issues, https://github.com/unknown/tqdm/issues
+        project_urls: Source, https://github.com/unknown/tqdm
+        "###);
+
+        let request = build_request(
+            &file,
+            &filename,
+            &Url::parse("https://example.org/upload").unwrap(),
+            &BaseClientBuilder::new().build(),
+            Some("ferris"),
+            Some("F3RR!S"),
+            form_metadata,
+        )
+        .await
+        .unwrap();
+
+        insta::with_settings!({
+            filters => [("boundary=[0-9a-f-]+", "boundary=[...]")],
+        }, {
+            assert_debug_snapshot!(&request, @r###"
+            RequestBuilder {
+                inner: RequestBuilder {
+                    method: POST,
+                    url: Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "example.org",
+                            ),
+                        ),
+                        port: None,
+                        path: "/upload",
+                        query: None,
+                        fragment: None,
+                    },
+                    headers: {
+                        "content-type": "multipart/form-data; boundary=[...]",
+                        "accept": "application/json;q=0.9, text/plain;q=0.8, text/html;q=0.7",
+                        "authorization": "Basic ZmVycmlzOkYzUlIhUw==",
+                    },
+                },
+                ..
+            }
+            "###);
+        });
+    }
+
+    /// Snapshot the data we send for an upload request for a wheel.
+    #[tokio::test]
+    async fn upload_request_wheel() {
+        let filename = "tqdm-4.66.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl";
+        let file = PathBuf::from("../../scripts/links/").join(filename);
+        let filename = DistFilename::try_from_normalized_filename(filename).unwrap();
+
+        let form_metadata = form_metadata(&file, &filename).await.unwrap();
+
+        let formatted_metadata = form_metadata
+            .iter()
+            .map(|(k, v)| format!("{k}: {v}"))
+            .join("\n");
+        assert_snapshot!(&formatted_metadata, @r###"
+        :action: file_upload
+        sha256_digest: 0d88ca657bc6b64995ca416e0c59c71af85cc10015d940fa446c42a8b485ee1c
+        protocol_version: 1
+        metadata_version: 2.1
+        name: tqdm
+        version: 4.66.1
+        filetype: bdist_wheel
+        pyversion: py3
+        summary: Fast, Extensible Progress Meter
+        description_content_type: text/x-rst
+        maintainer_email: tqdm developers <devs@tqdm.ml>
+        license: MPL-2.0 AND MIT
+        keywords: progressbar,progressmeter,progress,bar,meter,rate,eta,console,terminal,time
+        requires_python: >=3.7
+        classifiers: Development Status :: 5 - Production/Stable
+        classifiers: Environment :: Console
+        classifiers: Environment :: MacOS X
+        classifiers: Environment :: Other Environment
+        classifiers: Environment :: Win32 (MS Windows)
+        classifiers: Environment :: X11 Applications
+        classifiers: Framework :: IPython
+        classifiers: Framework :: Jupyter
+        classifiers: Intended Audience :: Developers
+        classifiers: Intended Audience :: Education
+        classifiers: Intended Audience :: End Users/Desktop
+        classifiers: Intended Audience :: Other Audience
+        classifiers: Intended Audience :: System Administrators
+        classifiers: License :: OSI Approved :: MIT License
+        classifiers: License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
+        classifiers: Operating System :: MacOS
+        classifiers: Operating System :: MacOS :: MacOS X
+        classifiers: Operating System :: Microsoft
+        classifiers: Operating System :: Microsoft :: MS-DOS
+        classifiers: Operating System :: Microsoft :: Windows
+        classifiers: Operating System :: POSIX
+        classifiers: Operating System :: POSIX :: BSD
+        classifiers: Operating System :: POSIX :: BSD :: FreeBSD
+        classifiers: Operating System :: POSIX :: Linux
+        classifiers: Operating System :: POSIX :: SunOS/Solaris
+        classifiers: Operating System :: Unix
+        classifiers: Programming Language :: Python
+        classifiers: Programming Language :: Python :: 3
+        classifiers: Programming Language :: Python :: 3.7
+        classifiers: Programming Language :: Python :: 3.8
+        classifiers: Programming Language :: Python :: 3.9
+        classifiers: Programming Language :: Python :: 3.10
+        classifiers: Programming Language :: Python :: 3.11
+        classifiers: Programming Language :: Python :: 3 :: Only
+        classifiers: Programming Language :: Python :: Implementation
+        classifiers: Programming Language :: Python :: Implementation :: IronPython
+        classifiers: Programming Language :: Python :: Implementation :: PyPy
+        classifiers: Programming Language :: Unix Shell
+        classifiers: Topic :: Desktop Environment
+        classifiers: Topic :: Education :: Computer Aided Instruction (CAI)
+        classifiers: Topic :: Education :: Testing
+        classifiers: Topic :: Office/Business
+        classifiers: Topic :: Other/Nonlisted Topic
+        classifiers: Topic :: Software Development :: Build Tools
+        classifiers: Topic :: Software Development :: Libraries
+        classifiers: Topic :: Software Development :: Libraries :: Python Modules
+        classifiers: Topic :: Software Development :: Pre-processors
+        classifiers: Topic :: Software Development :: User Interfaces
+        classifiers: Topic :: System :: Installation/Setup
+        classifiers: Topic :: System :: Logging
+        classifiers: Topic :: System :: Monitoring
+        classifiers: Topic :: System :: Shells
+        classifiers: Topic :: Terminals
+        classifiers: Topic :: Utilities
+        requires_dist: colorama ; platform_system == "Windows"
+        requires_dist: pytest >=6 ; extra == 'dev'
+        requires_dist: pytest-cov ; extra == 'dev'
+        requires_dist: pytest-timeout ; extra == 'dev'
+        requires_dist: pytest-xdist ; extra == 'dev'
+        requires_dist: ipywidgets >=6 ; extra == 'notebook'
+        requires_dist: slack-sdk ; extra == 'slack'
+        requires_dist: requests ; extra == 'telegram'
+        project_urls: homepage, https://tqdm.github.io
+        project_urls: repository, https://github.com/tqdm/tqdm
+        project_urls: changelog, https://tqdm.github.io/releases
+        project_urls: wiki, https://github.com/tqdm/tqdm/wiki
+        "###);
+
+        let request = build_request(
+            &file,
+            &filename,
+            &Url::parse("https://example.org/upload").unwrap(),
+            &BaseClientBuilder::new().build(),
+            Some("ferris"),
+            Some("F3RR!S"),
+            form_metadata,
+        )
+        .await
+        .unwrap();
+
+        insta::with_settings!({
+            filters => [("boundary=[0-9a-f-]+", "boundary=[...]")],
+        }, {
+            assert_debug_snapshot!(&request, @r###"
+            RequestBuilder {
+                inner: RequestBuilder {
+                    method: POST,
+                    url: Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "example.org",
+                            ),
+                        ),
+                        port: None,
+                        path: "/upload",
+                        query: None,
+                        fragment: None,
+                    },
+                    headers: {
+                        "content-type": "multipart/form-data; boundary=[...]",
+                        "accept": "application/json;q=0.9, text/plain;q=0.8, text/html;q=0.7",
+                        "authorization": "Basic ZmVycmlzOkYzUlIhUw==",
+                    },
+                },
+                ..
+            }
+            "###);
+        });
+    }
+}

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1370,8 +1370,9 @@ impl PythonSource {
     /// Whether a pre-release Python installation from the source should be used without opt-in.
     pub(crate) fn allows_prereleases(self) -> bool {
         match self {
-            Self::Managed | Self::Registry | Self::SearchPath | Self::MicrosoftStore => false,
-            Self::CondaPrefix
+            Self::Managed | Self::Registry | Self::MicrosoftStore => false,
+            Self::SearchPath
+            | Self::CondaPrefix
             | Self::ProvidedPath
             | Self::ParentInterpreter
             | Self::ActiveEnvironment

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -173,7 +173,7 @@ impl PythonDownloadRequest {
                     .with_version(version.clone()),
             ),
             PythonRequest::Key(request) => Some(request.clone()),
-            PythonRequest::Default => Some(Self::default()),
+            PythonRequest::Default | PythonRequest::Any => Some(Self::default()),
             // We can't download a managed installation for these request kinds
             PythonRequest::Directory(_)
             | PythonRequest::ExecutableName(_)

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -173,7 +173,7 @@ impl PythonDownloadRequest {
                     .with_version(version.clone()),
             ),
             PythonRequest::Key(request) => Some(request.clone()),
-            PythonRequest::Any => Some(Self::default()),
+            PythonRequest::Default => Some(Self::default()),
             // We can't download a managed installation for these request kinds
             PythonRequest::Directory(_)
             | PythonRequest::ExecutableName(_)

--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -80,7 +80,7 @@ impl fmt::Display for EnvironmentNotFound {
             EnvironmentPreference::OnlyVirtual => SearchType::Virtual,
         };
 
-        if matches!(self.request, PythonRequest::Default) {
+        if matches!(self.request, PythonRequest::Default | PythonRequest::Any) {
             write!(f, "No {search_type} found")?;
         } else {
             write!(f, "No {search_type} found for {}", self.request)?;

--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -80,7 +80,7 @@ impl fmt::Display for EnvironmentNotFound {
             EnvironmentPreference::OnlyVirtual => SearchType::Virtual,
         };
 
-        if matches!(self.request, PythonRequest::Any) {
+        if matches!(self.request, PythonRequest::Default) {
             write!(f, "No {search_type} found")?;
         } else {
             write!(f, "No {search_type} found for {}", self.request)?;

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -87,7 +87,7 @@ impl PythonInstallation {
         cache: &Cache,
         reporter: Option<&dyn Reporter>,
     ) -> Result<Self, Error> {
-        let request = request.unwrap_or_else(|| &PythonRequest::Any);
+        let request = request.unwrap_or_else(|| &PythonRequest::Default);
 
         // Search for the installation
         match Self::find(request, environments, preference, cache) {

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -416,7 +416,7 @@ mod tests {
         context.search_path = Some(vec![]);
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -430,7 +430,7 @@ mod tests {
         context.search_path = None;
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -454,7 +454,7 @@ mod tests {
 
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -478,7 +478,7 @@ mod tests {
 
         let interpreter = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -538,7 +538,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -569,7 +569,7 @@ mod tests {
 
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -605,7 +605,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -636,7 +636,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -657,7 +657,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -682,7 +682,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -707,7 +707,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -970,7 +970,7 @@ mod tests {
         let python =
             context.run_with_vars(&[("VIRTUAL_ENV", Some(venv.as_os_str()))], || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -995,7 +995,7 @@ mod tests {
         let python =
             context.run_with_vars(&[("VIRTUAL_ENV", Some(venv.as_os_str()))], || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1020,7 +1020,7 @@ mod tests {
             context.run_with_vars(&[("CONDA_PREFIX", Some(condaenv.as_os_str()))], || {
                 // Note this python is not treated as a system interpreter
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::OnlyVirtual,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1050,7 +1050,7 @@ mod tests {
             ],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1069,7 +1069,7 @@ mod tests {
         let python =
             context.run_with_vars(&[("CONDA_PREFIX", Some(condaenv.as_os_str()))], || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1094,7 +1094,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1111,7 +1111,7 @@ mod tests {
         context.add_python_versions(&["3.12.1", "3.12.2"])?;
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1139,7 +1139,7 @@ mod tests {
         let python =
             context.run_with_vars(&[("VIRTUAL_ENV", Some(venv.as_os_str()))], || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1172,7 +1172,7 @@ mod tests {
             &[("UV_INTERNAL__PARENT_INTERPRETER", Some(parent.as_os_str()))],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1196,7 +1196,7 @@ mod tests {
             ],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1217,7 +1217,7 @@ mod tests {
             ],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::ExplicitSystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1238,7 +1238,7 @@ mod tests {
             ],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::OnlySystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1259,7 +1259,7 @@ mod tests {
             ],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::OnlyVirtual,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1292,7 +1292,7 @@ mod tests {
             &[("UV_INTERNAL__PARENT_INTERPRETER", Some(parent.as_os_str()))],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1319,7 +1319,7 @@ mod tests {
         let python =
             context.run_with_vars(&[("VIRTUAL_ENV", Some(venv.as_os_str()))], || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::OnlySystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1371,7 +1371,7 @@ mod tests {
 
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlyVirtual,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1422,7 +1422,7 @@ mod tests {
 
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1767,7 +1767,7 @@ mod tests {
         context.add_python_interpreters(&[(true, ImplementationName::PyPy, "pypy", "3.10.0")])?;
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1783,7 +1783,7 @@ mod tests {
         context.add_python_interpreters(&[(true, ImplementationName::PyPy, "python", "3.10.1")])?;
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1836,7 +1836,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -2110,7 +2110,7 @@ mod tests {
         )])?;
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -2131,7 +2131,7 @@ mod tests {
         )])?;
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -2184,7 +2184,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -305,7 +305,7 @@ impl ManagedPythonInstallation {
     pub fn satisfies(&self, request: &PythonRequest) -> bool {
         match request {
             PythonRequest::File(path) => self.executable() == *path,
-            PythonRequest::Default => true,
+            PythonRequest::Default | PythonRequest::Any => true,
             PythonRequest::Directory(path) => self.path() == *path,
             PythonRequest::ExecutableName(name) => self
                 .executable()

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -305,7 +305,7 @@ impl ManagedPythonInstallation {
     pub fn satisfies(&self, request: &PythonRequest) -> bool {
         match request {
             PythonRequest::File(path) => self.executable() == *path,
-            PythonRequest::Any => true,
+            PythonRequest::Default => true,
             PythonRequest::Directory(path) => self.path() == *path,
             PythonRequest::ExecutableName(name) => self
                 .executable()

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Formatter;
 use std::sync::Arc;
 
+use indexmap::IndexSet;
 use pubgrub::{DefaultStringReporter, DerivationTree, Derived, External, Range, Reporter};
 use rustc_hash::FxHashMap;
 
@@ -248,7 +249,8 @@ impl std::fmt::Display for NoSolutionError {
         write!(f, "{report}")?;
 
         // Include any additional hints.
-        for hint in formatter.hints(
+        let mut additional_hints = IndexSet::default();
+        formatter.generate_hints(
             &self.error,
             &self.selector,
             &self.index_locations,
@@ -256,7 +258,9 @@ impl std::fmt::Display for NoSolutionError {
             &self.incomplete_packages,
             &self.fork_urls,
             &self.markers,
-        ) {
+            &mut additional_hints,
+        );
+        for hint in additional_hints {
             write!(f, "\n\n{hint}")?;
         }
 

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -36,6 +36,7 @@ textwrap = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["uv-options-metadata", "clap"]

--- a/crates/uv-settings/src/combine.rs
+++ b/crates/uv-settings/src/combine.rs
@@ -1,9 +1,9 @@
-use std::num::NonZeroUsize;
-use std::path::PathBuf;
-
 use distribution_types::IndexUrl;
 use install_wheel_rs::linker::LinkMode;
 use pypi_types::SupportedEnvironments;
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use url::Url;
 use uv_configuration::{ConfigSettings, IndexStrategy, KeyringProviderType, TargetTriple};
 use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
 use uv_resolver::{AnnotationStyle, ExcludeNewer, PrereleaseMode, ResolutionMode};
@@ -71,6 +71,7 @@ impl_combine_or!(AnnotationStyle);
 impl_combine_or!(ExcludeNewer);
 impl_combine_or!(IndexStrategy);
 impl_combine_or!(IndexUrl);
+impl_combine_or!(Url);
 impl_combine_or!(KeyringProviderType);
 impl_combine_or!(LinkMode);
 impl_combine_or!(NonZeroUsize);

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -1,11 +1,11 @@
 use std::{fmt::Debug, num::NonZeroUsize, path::PathBuf};
 
-use serde::{Deserialize, Serialize};
-
 use distribution_types::{FlatIndexLocation, IndexUrl, StaticMetadata};
 use install_wheel_rs::linker::LinkMode;
 use pep508_rs::Requirement;
 use pypi_types::{SupportedEnvironments, VerbatimParsedUrl};
+use serde::{Deserialize, Serialize};
+use url::Url;
 use uv_cache_info::CacheKey;
 use uv_configuration::{
     ConfigSettings, IndexStrategy, KeyringProviderType, PackageNameSpecifier, TargetTriple,
@@ -40,6 +40,8 @@ pub struct Options {
     pub globals: GlobalOptions,
     #[serde(flatten)]
     pub top_level: ResolverInstallerOptions,
+    #[serde(flatten)]
+    pub publish: PublishOptions,
     #[option_group]
     pub pip: Option<PipOptions>,
 
@@ -1471,4 +1473,22 @@ impl From<ToolOptions> for ResolverInstallerOptions {
             no_binary_package: value.no_binary_package,
         }
     }
+}
+
+#[derive(
+    Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, CombineOptions, OptionsMetadata,
+)]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct PublishOptions {
+    /// The URL for publishing packages to the Python package index (by default:
+    /// <https://upload.pypi.org/legacy>).
+    #[option(
+        default = "\"https://upload.pypi.org/legacy\"",
+        value_type = "str",
+        example = r#"
+            publish-url = "https://test.pypi.org/simple"
+        "#
+    )]
+    pub publish_url: Option<Url>,
 }

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -108,7 +108,7 @@ pub(crate) fn create(
                     return Err(Error::Io(io::Error::new(
                         io::ErrorKind::AlreadyExists,
                         format!(
-                            "The directory `{}` exists, but it's not a virtualenv",
+                            "The directory `{}` exists, but it's not a virtual environment",
                             location.user_display()
                         ),
                     )));

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 pypi-types = { workspace = true }
-uv-fs = { workspace = true, features = ["tokio"] }
+uv-fs = { workspace = true, features = ["tokio", "schemars"] }
 uv-git = { workspace = true }
 uv-macros = { workspace = true }
 uv-normalize = { workspace = true }

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -17,7 +17,7 @@ use url::Url;
 
 use pep440_rs::{Version, VersionSpecifiers};
 use pypi_types::{RequirementSource, SupportedEnvironments, VerbatimParsedUrl};
-use uv_fs::relative_to;
+use uv_fs::{relative_to, PortablePathBuf};
 use uv_git::GitReference;
 use uv_macros::OptionsMetadata;
 use uv_normalize::{ExtraName, PackageName};
@@ -413,7 +413,7 @@ pub enum Source {
         /// The repository URL (without the `git+` prefix).
         git: Url,
         /// The path to the directory with the `pyproject.toml`, if it's not in the archive root.
-        subdirectory: Option<PathBuf>,
+        subdirectory: Option<PortablePathBuf>,
         // Only one of the three may be used; we'll validate this later and emit a custom error.
         rev: Option<String>,
         tag: Option<String>,
@@ -430,13 +430,13 @@ pub enum Source {
         url: Url,
         /// For source distributions, the path to the directory with the `pyproject.toml`, if it's
         /// not in the archive root.
-        subdirectory: Option<PathBuf>,
+        subdirectory: Option<PortablePathBuf>,
     },
     /// The path to a dependency, either a wheel (a `.whl` file), source distribution (a `.zip` or
     /// `.tar.gz` file), or source tree (i.e., a directory containing a `pyproject.toml` or
     /// `setup.py` file in the root).
     Path {
-        path: PathBuf,
+        path: PortablePathBuf,
         /// `false` by default.
         editable: Option<bool>,
     },
@@ -454,12 +454,12 @@ pub enum Source {
     /// A catch-all variant used to emit precise error messages when deserializing.
     CatchAll {
         git: String,
-        subdirectory: Option<PathBuf>,
+        subdirectory: Option<PortablePathBuf>,
         rev: Option<String>,
         tag: Option<String>,
         branch: Option<String>,
         url: String,
-        path: PathBuf,
+        path: PortablePathBuf,
         index: String,
         workspace: bool,
     },
@@ -534,15 +534,17 @@ impl Source {
             RequirementSource::Path { install_path, .. }
             | RequirementSource::Directory { install_path, .. } => Source::Path {
                 editable,
-                path: relative_to(&install_path, root)
-                    .or_else(|_| std::path::absolute(&install_path))
-                    .map_err(SourceError::Absolute)?,
+                path: PortablePathBuf::from(
+                    relative_to(&install_path, root)
+                        .or_else(|_| std::path::absolute(&install_path))
+                        .map_err(SourceError::Absolute)?,
+                ),
             },
             RequirementSource::Url {
                 subdirectory, url, ..
             } => Source::Url {
                 url: url.to_url(),
-                subdirectory,
+                subdirectory: subdirectory.map(PortablePathBuf::from),
             },
             RequirementSource::Git {
                 repository,
@@ -566,7 +568,7 @@ impl Source {
                         tag,
                         branch,
                         git: repository,
-                        subdirectory,
+                        subdirectory: subdirectory.map(PortablePathBuf::from),
                     }
                 } else {
                     Source::Git {
@@ -574,7 +576,7 @@ impl Source {
                         tag,
                         branch,
                         git: repository,
-                        subdirectory,
+                        subdirectory: subdirectory.map(PortablePathBuf::from),
                     }
                 }
             }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -35,6 +35,7 @@ uv-fs = { workspace = true }
 uv-git = { workspace = true }
 uv-installer = { workspace = true }
 uv-normalize = { workspace = true }
+uv-publish = { workspace = true }
 uv-python = { workspace = true, features = ["schemars"]}
 uv-requirements = { workspace = true }
 uv-resolver = { workspace = true }

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub(crate) use project::remove::remove;
 pub(crate) use project::run::{run, RunCommand};
 pub(crate) use project::sync::sync;
 pub(crate) use project::tree::tree;
+pub(crate) use publish::publish;
 pub(crate) use python::dir::dir as python_dir;
 pub(crate) use python::find::find as python_find;
 pub(crate) use python::install::install as python_install;
@@ -70,6 +71,7 @@ pub(crate) mod reporters;
 mod tool;
 
 mod build;
+mod publish;
 #[cfg(feature = "self-update")]
 mod self_update;
 mod venv;

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -139,7 +139,7 @@ pub(crate) async fn add(
                 request
             } else {
                 // (3) Assume any Python version
-                PythonRequest::Any
+                PythonRequest::Default
             };
 
             let interpreter = PythonInstallation::find_or_download(

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -503,7 +503,7 @@ pub(crate) async fn get_or_init_environment(
 
             writeln!(
                 printer.stderr(),
-                "Creating virtualenv at: {}",
+                "Creating virtual environment at: {}",
                 venv.user_display().cyan()
             )?;
 

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -1,0 +1,74 @@
+use crate::commands::{human_readable_bytes, ExitStatus};
+use crate::printer::Printer;
+use anyhow::{bail, Result};
+use owo_colors::OwoColorize;
+use std::fmt::Write;
+use tracing::info;
+use url::Url;
+use uv_client::{BaseClientBuilder, Connectivity};
+use uv_configuration::{KeyringProviderType, TrustedHost};
+use uv_publish::{files_for_publishing, upload};
+
+pub(crate) async fn publish(
+    paths: Vec<String>,
+    publish_url: Url,
+    keyring_provider: KeyringProviderType,
+    allow_insecure_host: Vec<TrustedHost>,
+    username: Option<String>,
+    password: Option<String>,
+    connectivity: Connectivity,
+    native_tls: bool,
+    printer: Printer,
+) -> Result<ExitStatus> {
+    if connectivity.is_offline() {
+        bail!("You cannot publish files in offline mode");
+    }
+
+    let files = files_for_publishing(paths)?;
+    match files.len() {
+        0 => bail!("No files found to publish"),
+        1 => writeln!(printer.stderr(), "Publishing 1 file")?,
+        n => writeln!(printer.stderr(), "Publishing {n} files")?,
+    }
+
+    let client = BaseClientBuilder::new()
+        // https://github.com/seanmonstar/reqwest/issues/2416
+        .retries(0)
+        .keyring(keyring_provider)
+        .native_tls(native_tls)
+        .allow_insecure_host(allow_insecure_host)
+        // Don't try cloning the request to make an unauthenticated request first.
+        // https://github.com/seanmonstar/reqwest/issues/2416
+        .only_authenticated(true)
+        .build();
+
+    for (file, filename) in files {
+        let size = file.metadata()?.len();
+        let (bytes, unit) = human_readable_bytes(size);
+        writeln!(
+            printer.stderr(),
+            "{} {filename} {}",
+            "Uploading".bold().green(),
+            format!("({bytes:.1}{unit})").dimmed()
+        )?;
+        let uploaded = upload(
+            &file,
+            &filename,
+            &publish_url,
+            &client,
+            username.as_deref(),
+            password.as_deref(),
+        )
+        .await?; // Filename and/or URL are already attached, if applicable.
+        info!("Upload succeeded");
+        if !uploaded {
+            writeln!(
+                printer.stderr(),
+                "{}",
+                "File already existed, skipping".dimmed()
+            )?;
+        }
+    }
+
+    Ok(ExitStatus::Success)
+}

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -41,7 +41,7 @@ pub(crate) async fn install(
         PythonVersionFile::discover(&*CWD, no_config, true)
             .await?
             .map(uv_python::PythonVersionFile::into_versions)
-            .unwrap_or_else(|| vec![PythonRequest::Any])
+            .unwrap_or_else(|| vec![PythonRequest::Default])
     } else {
         targets
             .iter()
@@ -62,7 +62,7 @@ pub(crate) async fn install(
     let mut unfilled_requests = Vec::new();
     let mut uninstalled = Vec::new();
     for (request, download_request) in requests.iter().zip(download_requests) {
-        if matches!(requests.as_slice(), [PythonRequest::Any]) {
+        if matches!(requests.as_slice(), [PythonRequest::Default]) {
             writeln!(printer.stderr(), "Searching for Python installations")?;
         } else {
             writeln!(
@@ -75,7 +75,7 @@ pub(crate) async fn install(
             .iter()
             .find(|installation| download_request.satisfied_by_key(installation.key()))
         {
-            if matches!(request, PythonRequest::Any) {
+            if matches!(request, PythonRequest::Default) {
                 writeln!(printer.stderr(), "Found: {}", installation.key().green())?;
             } else {
                 writeln!(
@@ -96,7 +96,7 @@ pub(crate) async fn install(
     }
 
     if unfilled_requests.is_empty() {
-        if matches!(requests.as_slice(), [PythonRequest::Any]) {
+        if matches!(requests.as_slice(), [PythonRequest::Default]) {
             writeln!(
                 printer.stderr(),
                 "Python is already available. Use `uv python install <request>` to install a specific version.",

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -66,7 +66,7 @@ pub(crate) async fn list(
     };
 
     let installed = find_python_installations(
-        &PythonRequest::Default,
+        &PythonRequest::Any,
         EnvironmentPreference::OnlySystem,
         python_preference,
         cache,

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -66,7 +66,7 @@ pub(crate) async fn list(
     };
 
     let installed = find_python_installations(
-        &PythonRequest::Any,
+        &PythonRequest::Default,
         EnvironmentPreference::OnlySystem,
         python_preference,
         cache,

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -59,7 +59,7 @@ async fn do_uninstall(
     let start = std::time::Instant::now();
 
     let requests = if all {
-        vec![PythonRequest::Any]
+        vec![PythonRequest::Default]
     } else {
         let targets = targets.into_iter().collect::<BTreeSet<_>>();
         targets
@@ -82,7 +82,7 @@ async fn do_uninstall(
     let installed_installations: Vec<_> = installations.find_all()?.collect();
     let mut matching_installations = BTreeSet::default();
     for (request, download_request) in requests.iter().zip(download_requests) {
-        if matches!(requests.as_slice(), [PythonRequest::Any]) {
+        if matches!(requests.as_slice(), [PythonRequest::Default]) {
             writeln!(printer.stderr(), "Searching for Python installations")?;
         } else {
             writeln!(
@@ -100,7 +100,7 @@ async fn do_uninstall(
             matching_installations.insert(installation.clone());
         }
         if !found {
-            if matches!(requests.as_slice(), [PythonRequest::Any]) {
+            if matches!(requests.as_slice(), [PythonRequest::Default]) {
                 writeln!(printer.stderr(), "No Python installations found")?;
                 return Ok(ExitStatus::Failure);
             }

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -244,7 +244,7 @@ async fn venv_impl(
 
     writeln!(
         printer.stderr(),
-        "Creating virtualenv {}at: {}",
+        "Creating virtual environment {}at: {}",
         if seed { "with seed packages " } else { "" },
         path.user_display().cyan()
     )

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -31,6 +31,7 @@ use crate::printer::Printer;
 use crate::settings::{
     CacheSettings, GlobalSettings, PipCheckSettings, PipCompileSettings, PipFreezeSettings,
     PipInstallSettings, PipListSettings, PipShowSettings, PipSyncSettings, PipUninstallSettings,
+    PublishSettings,
 };
 
 #[cfg(target_os = "windows")]
@@ -1062,6 +1063,31 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         }) => {
             commands::python_dir()?;
             Ok(ExitStatus::Success)
+        }
+        Commands::Publish(args) => {
+            show_settings!(args);
+            // Resolve the settings from the command-line arguments and workspace configuration.
+            let PublishSettings {
+                files,
+                username,
+                password,
+                publish_url,
+                keyring_provider,
+                allow_insecure_host,
+            } = PublishSettings::resolve(args, filesystem);
+
+            commands::publish(
+                files,
+                publish_url,
+                keyring_provider,
+                allow_insecure_host,
+                username,
+                password,
+                globals.connectivity,
+                globals.native_tls,
+                printer,
+            )
+            .await
         }
     }
 }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -8,10 +8,11 @@ use distribution_types::{DependencyMetadata, IndexLocations};
 use install_wheel_rs::linker::LinkMode;
 use pep508_rs::{ExtraName, RequirementOrigin};
 use pypi_types::{Requirement, SupportedEnvironments};
+use url::Url;
 use uv_cache::{CacheArgs, Refresh};
 use uv_cli::{
     options::{flag, resolver_installer_options, resolver_options},
-    BuildArgs, ExportArgs, ToolUpgradeArgs,
+    BuildArgs, ExportArgs, PublishArgs, ToolUpgradeArgs,
 };
 use uv_cli::{
     AddArgs, ColorChoice, ExternalCommand, GlobalArgs, InitArgs, ListFormat, LockArgs, Maybe,
@@ -30,13 +31,17 @@ use uv_normalize::PackageName;
 use uv_python::{Prefix, PythonDownloads, PythonPreference, PythonVersion, Target};
 use uv_resolver::{AnnotationStyle, DependencyMode, ExcludeNewer, PrereleaseMode, ResolutionMode};
 use uv_settings::{
-    Combine, FilesystemOptions, Options, PipOptions, ResolverInstallerOptions, ResolverOptions,
+    Combine, FilesystemOptions, Options, PipOptions, PublishOptions, ResolverInstallerOptions,
+    ResolverOptions,
 };
 use uv_warnings::warn_user_once;
 use uv_workspace::pyproject::DependencyType;
 
 use crate::commands::ToolRunCommand;
 use crate::commands::{pip::operations::Modifications, InitProjectKind};
+
+/// The default publish URL.
+const PYPI_PUBLISH_URL: &str = "https://upload.pypi.org/legacy/";
 
 /// The resolved global settings to use for any invocation of the CLI.
 #[allow(clippy::struct_excessive_bools)]
@@ -2415,6 +2420,72 @@ impl<'a> From<ResolverInstallerSettingsRef<'a>> for InstallerSettingsRef<'a> {
             reinstall: settings.reinstall,
             build_options: settings.build_options,
             sources: settings.sources,
+        }
+    }
+}
+
+/// The resolved settings to use for an invocation of the `uv publish` CLI.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone)]
+pub(crate) struct PublishSettings {
+    // CLI only, see [`PublishArgs`] for docs.
+    pub(crate) files: Vec<String>,
+    pub(crate) username: Option<String>,
+    pub(crate) password: Option<String>,
+
+    // Both CLI and configuration.
+    pub(crate) publish_url: Url,
+    pub(crate) keyring_provider: KeyringProviderType,
+    pub(crate) allow_insecure_host: Vec<TrustedHost>,
+}
+
+impl PublishSettings {
+    /// Resolve the [`crate::settings::PublishSettings`] from the CLI and filesystem configuration.
+    pub(crate) fn resolve(args: PublishArgs, filesystem: Option<FilesystemOptions>) -> Self {
+        let Options {
+            publish, top_level, ..
+        } = filesystem
+            .map(FilesystemOptions::into_options)
+            .unwrap_or_default();
+
+        let PublishOptions { publish_url } = publish;
+        let ResolverInstallerOptions {
+            keyring_provider,
+            allow_insecure_host,
+            ..
+        } = top_level;
+
+        // Tokens are encoded in the same way as username/password
+        let (username, password) = if let Some(token) = args.token {
+            (Some("__token__".to_string()), Some(token))
+        } else {
+            (args.username, args.password)
+        };
+
+        Self {
+            files: args.files,
+            username,
+            password,
+            publish_url: args
+                .publish_url
+                .combine(publish_url)
+                // TODO(reviewer): This is different from how it's done anywhere else, but i haven't
+                // figured out what the ergonomic pattern is?
+                .unwrap_or(Url::parse(PYPI_PUBLISH_URL).unwrap()),
+            keyring_provider: args
+                .keyring_provider
+                .combine(keyring_provider)
+                .unwrap_or_default(),
+            allow_insecure_host: args
+                .allow_insecure_host
+                .map(|allow_insecure_host| {
+                    allow_insecure_host
+                        .into_iter()
+                        .filter_map(Maybe::into_option)
+                        .collect()
+                })
+                .combine(allow_insecure_host)
+                .unwrap_or_default(),
         }
     }
 }

--- a/crates/uv/tests/cache_clean.rs
+++ b/crates/uv/tests/cache_clean.rs
@@ -57,7 +57,7 @@ fn clean_package_pypi() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v12")
+        .child("simple-v13")
         .child("pypi")
         .child("iniconfig.rkyv");
     assert!(
@@ -129,7 +129,7 @@ fn clean_package_index() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v12")
+        .child("simple-v13")
         .child("index")
         .child("e8208120cae3ba69")
         .child("iniconfig.rkyv");

--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -184,7 +184,7 @@ fn prune_unzipped() -> Result<()> {
     " })?;
 
     // Install a requirement, to populate the cache.
-    uv_snapshot!(context.filters(), context.pip_sync().env_remove("UV_EXCLUDE_NEWER").arg("requirements.txt").arg("--reinstall"), @r###"
+    uv_snapshot!(context.filters(), context.pip_install().arg("-r").env_remove("UV_EXCLUDE_NEWER").arg("requirements.txt").arg("--reinstall"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -204,15 +204,17 @@ fn prune_unzipped() -> Result<()> {
 
     ----- stderr -----
     Pruning cache at: [CACHE_DIR]/
-    Removed 170 files ([SIZE])
+    Removed 171 files ([SIZE])
     "###);
+
+    context.venv().assert().success();
 
     // Reinstalling the source distribution should not require re-downloading the source
     // distribution.
     requirements_txt.write_str(indoc! { r"
         source-distribution==0.0.1
     " })?;
-    uv_snapshot!(context.filters(), context.pip_sync().env_remove("UV_EXCLUDE_NEWER").arg("requirements.txt").arg("--reinstall").arg("--offline"), @r###"
+    uv_snapshot!(context.filters(), context.pip_install().arg("-r").env_remove("UV_EXCLUDE_NEWER").arg("requirements.txt").arg("--offline"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -220,26 +222,33 @@ fn prune_unzipped() -> Result<()> {
     ----- stderr -----
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
-    Uninstalled 2 packages in [TIME]
     Installed 1 package in [TIME]
-     - iniconfig==2.0.0
-     ~ source-distribution==0.0.1
+     + source-distribution==0.0.1
     "###);
 
     // But reinstalling the other package should require a download, since we pruned the wheel.
     requirements_txt.write_str(indoc! { r"
         iniconfig
     " })?;
-    uv_snapshot!(context.filters(), context.pip_sync().env_remove("UV_EXCLUDE_NEWER").arg("requirements.txt").arg("--reinstall").arg("--offline"), @r###"
+    uv_snapshot!(context.filters(), context.pip_install().arg("-r").env_remove("UV_EXCLUDE_NEWER").arg("requirements.txt").arg("--offline"), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 1 package in [TIME]
-    error: Failed to prepare distributions
-      Caused by: Failed to fetch wheel: iniconfig==2.0.0
-      Caused by: Network connectivity is disabled, but the requested data wasn't found in the cache for: `https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only the following versions of iniconfig are available:
+              iniconfig<=0.1
+              iniconfig>=1.0.0
+          and all of:
+              iniconfig<=0.1
+              iniconfig>=1.0.0
+          need to be downloaded from a registry, we can conclude that iniconfig<1.0.0 cannot be used.
+          And because you require iniconfig, we can conclude that your requirements are unsatisfiable.
+
+          hint: Pre-releases are available for iniconfig in the requested range (e.g., 0.2.dev0), but pre-releases weren't enabled (try: `--prerelease=allow`)
+
+          hint: Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.
     "###);
 
     Ok(())

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -52,7 +52,7 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"tv_sec: \d+", "tv_sec: [TIME]"),
     (r"tv_nsec: \d+", "tv_nsec: [TIME]"),
     // Rewrite Windows output to Unix output
-    (r"\\([\w\d])", "/$1"),
+    (r"\\([\w\d]|\.\.)", "/$1"),
     (r"uv.exe", "uv"),
     // uv version display
     (
@@ -576,6 +576,21 @@ impl TestContext {
         let mut command = Command::new(get_bin());
         command.arg("build");
         self.add_shared_args(&mut command, false);
+        command
+    }
+
+    /// Create a `uv publish` command with options shared across scenarios.
+    #[expect(clippy::unused_self)] // For consistency
+    pub fn publish(&self) -> Command {
+        let mut command = Command::new(get_bin());
+        command.arg("publish");
+
+        if cfg!(all(windows, debug_assertions)) {
+            // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
+            // default windows stack of 1MB
+            command.env("UV_STACK_SIZE", (4 * 1024 * 1024).to_string());
+        }
+
         command
     }
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -351,11 +351,11 @@ impl TestContext {
         // Make virtual environment activation cross-platform and shell-agnostic
         filters.push((
             r"Activate with: (.*)\\Scripts\\activate".to_string(),
-            "Activate with: source $1/bin/activate".to_string(),
+            "Activate with: source $1/[BIN]/activate".to_string(),
         ));
         filters.push((
-            r"Activate with: source .venv/bin/activate(?:\.\w+)".to_string(),
-            "Activate with: source .venv/bin/activate".to_string(),
+            r"Activate with: source (.*)/bin/activate(?:\.\w+)?".to_string(),
+            "Activate with: source $1/[BIN]/activate".to_string(),
         ));
 
         // Account for [`Simplified::user_display`] which is relative to the command working directory

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -2040,7 +2040,7 @@ fn add_path() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -5,6 +5,7 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use indoc::indoc;
 use insta::assert_snapshot;
+use std::path::Path;
 
 use crate::common::{decode_token, packse_index_url};
 use common::{uv_snapshot, TestContext};
@@ -2019,7 +2020,7 @@ fn add_path() -> Result<()> {
         build-backend = "setuptools.build_meta"
     "#})?;
 
-    let child = workspace.child("child");
+    let child = workspace.child("packages").child("child");
     child.child("pyproject.toml").write_str(indoc! {r#"
         [project]
         name = "child"
@@ -2032,7 +2033,7 @@ fn add_path() -> Result<()> {
         build-backend = "setuptools.build_meta"
     "#})?;
 
-    uv_snapshot!(context.filters(), context.add().arg("./child").current_dir(workspace.path()), @r###"
+    uv_snapshot!(context.filters(), context.add().arg(Path::new("packages").join("child")).current_dir(workspace.path()), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2043,7 +2044,7 @@ fn add_path() -> Result<()> {
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
-     + child==0.1.0 (from file://[TEMP_DIR]/workspace/child)
+     + child==0.1.0 (from file://[TEMP_DIR]/workspace/packages/child)
      + parent==0.1.0 (from file://[TEMP_DIR]/workspace)
     "###);
 
@@ -2067,7 +2068,7 @@ fn add_path() -> Result<()> {
         build-backend = "setuptools.build_meta"
 
         [tool.uv.sources]
-        child = { path = "child" }
+        child = { path = "packages/child" }
         "###
         );
     });
@@ -2089,7 +2090,7 @@ fn add_path() -> Result<()> {
         [[package]]
         name = "child"
         version = "0.1.0"
-        source = { directory = "child" }
+        source = { directory = "packages/child" }
 
         [[package]]
         name = "parent"
@@ -2100,7 +2101,7 @@ fn add_path() -> Result<()> {
         ]
 
         [package.metadata]
-        requires-dist = [{ name = "child", directory = "child" }]
+        requires-dist = [{ name = "child", directory = "packages/child" }]
         "###
         );
     });

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -29,6 +29,7 @@ fn help() {
       pip                        Manage Python packages with a pip-compatible interface
       venv                       Create a virtual environment
       build                      Build Python packages into source distributions and wheels
+      publish                    Upload distributions to an index
       cache                      Manage uv's cache
       version                    Display uv's version
       generate-shell-completion  Generate shell completion
@@ -94,6 +95,7 @@ fn help_flag() {
       pip      Manage Python packages with a pip-compatible interface
       venv     Create a virtual environment
       build    Build Python packages into source distributions and wheels
+      publish  Upload distributions to an index
       cache    Manage uv's cache
       version  Display uv's version
       help     Display documentation for a command
@@ -157,6 +159,7 @@ fn help_short_flag() {
       pip      Manage Python packages with a pip-compatible interface
       venv     Create a virtual environment
       build    Build Python packages into source distributions and wheels
+      publish  Upload distributions to an index
       cache    Manage uv's cache
       version  Display uv's version
       help     Display documentation for a command
@@ -637,6 +640,7 @@ fn help_unknown_subcommand() {
         pip
         venv
         build
+        publish
         cache
         version
         generate-shell-completion
@@ -662,6 +666,7 @@ fn help_unknown_subcommand() {
         pip
         venv
         build
+        publish
         cache
         version
         generate-shell-completion
@@ -714,6 +719,7 @@ fn help_with_global_option() {
       pip                        Manage Python packages with a pip-compatible interface
       venv                       Create a virtual environment
       build                      Build Python packages into source distributions and wheels
+      publish                    Upload distributions to an index
       cache                      Manage uv's cache
       version                    Display uv's version
       generate-shell-completion  Generate shell completion
@@ -815,6 +821,7 @@ fn help_with_no_pager() {
       pip                        Manage Python packages with a pip-compatible interface
       venv                       Create a virtual environment
       build                      Build Python packages into source distributions and wheels
+      publish                    Upload distributions to an index
       cache                      Manage uv's cache
       version                    Display uv's version
       generate-shell-completion  Generate shell completion

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -128,7 +128,7 @@ fn init_application() -> Result<()> {
     ----- stderr -----
     warning: `VIRTUAL_ENV=[VENV]/` does not match the project environment path `.venv` and will be ignored
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 1 package in [TIME]
     Audited in [TIME]
     "###);
@@ -309,7 +309,7 @@ fn init_application_package() -> Result<()> {
     ----- stderr -----
     warning: `VIRTUAL_ENV=[VENV]/` does not match the project environment path `.venv` and will be ignored
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -391,7 +391,7 @@ fn init_library() -> Result<()> {
     ----- stderr -----
     warning: `VIRTUAL_ENV=[VENV]/` does not match the project environment path `.venv` and will be ignored
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -6035,7 +6035,7 @@ fn lock_redact_https() -> Result<()> {
 /// However, we don't currently avoid persisting Git credentials in `uv.lock`.
 #[test]
 fn lock_redact_git_pep508() -> Result<()> {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_link_mode_warning();
     let token = decode_token(common::READ_ONLY_GITHUB_TOKEN);
 
     let filters: Vec<_> = [(token.as_str(), "***")]
@@ -6129,7 +6129,7 @@ fn lock_redact_git_pep508() -> Result<()> {
 /// However, we don't currently avoid persisting Git credentials in `uv.lock`.
 #[test]
 fn lock_redact_git_sources() -> Result<()> {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_link_mode_warning();
     let token = decode_token(common::READ_ONLY_GITHUB_TOKEN);
 
     let filters: Vec<_> = [(token.as_str(), "***")]

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -7166,7 +7166,7 @@ fn lock_find_links_local_wheel() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Prepared 1 package in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/workspace)
@@ -7282,7 +7282,7 @@ fn lock_find_links_local_sdist() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/workspace)
@@ -8444,7 +8444,7 @@ fn lock_mixed_extras() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + leaf1==0.1.0 (from file://[TEMP_DIR]/workspace1/packages/leaf1)
@@ -8623,7 +8623,7 @@ fn lock_transitive_extra() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + leaf==0.1.0 (from file://[TEMP_DIR]/workspace/packages/leaf)

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -5589,7 +5589,7 @@ fn sync_seed() -> Result<()> {
      + pip==24.0
      + setuptools==69.2.0
      + wheel==0.43.0
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -5585,7 +5585,7 @@ fn sync_seed() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.8.[X] interpreter at: [PYTHON-3.8]
-    Creating virtualenv with seed packages at: .venv
+    Creating virtual environment with seed packages at: .venv
      + pip==24.0
      + setuptools==69.2.0
      + wheel==0.43.0

--- a/crates/uv/tests/publish.rs
+++ b/crates/uv/tests/publish.rs
@@ -1,0 +1,51 @@
+#![cfg(feature = "pypi")]
+
+use common::{uv_snapshot, TestContext};
+
+mod common;
+
+#[test]
+fn username_password_no_longer_supported() {
+    let context = TestContext::new("3.12");
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("-u")
+        .arg("dummy")
+        .arg("-p")
+        .arg("dummy")
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 1 file
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
+    error: Failed to publish `../../scripts/links/ok-1.0.0-py3-none-any.whl` to `https://upload.pypi.org/legacy/`
+      Caused by: Incorrect credentials (status code 403 Forbidden): 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://pypi.org/help/#apitoken and https://pypi.org/help/#trusted-publishers
+    "###
+    );
+}
+
+#[test]
+fn invalid_token() {
+    let context = TestContext::new("3.12");
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("-u")
+        .arg("__token__")
+        .arg("-p")
+        .arg("dummy")
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 1 file
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
+    error: Failed to publish `../../scripts/links/ok-1.0.0-py3-none-any.whl` to `https://upload.pypi.org/legacy/`
+      Caused by: Incorrect credentials (status code 403 Forbidden): 403 Invalid or non-existent authentication information. See https://pypi.org/help/#invalid-auth for more information.
+    "###
+    );
+}

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -56,7 +56,7 @@ fn run_with_python_version() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 5 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -106,7 +106,7 @@ fn run_with_python_version() -> Result<()> {
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Removed virtual environment at: .venv
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 5 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 4 packages in [TIME]
@@ -1364,7 +1364,7 @@ fn run_from_directory() -> Result<()> {
     ----- stderr -----
     warning: `VIRTUAL_ENV=[VENV]/` does not match the project environment path `.venv` and will be ignored
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -1463,7 +1463,7 @@ fn run_isolated_python_version() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.8.[X] interpreter at: [PYTHON-3.8]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -359,7 +359,7 @@ fn mixed_requires_python() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 5 packages in [TIME]
     Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
@@ -1189,7 +1189,7 @@ fn no_install_workspace() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + idna==3.6
@@ -1652,7 +1652,7 @@ fn sync_custom_environment_path() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: foo
+    Creating virtual environment at: foo
     Resolved 2 packages in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
@@ -1677,7 +1677,7 @@ fn sync_custom_environment_path() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: foobar/.venv
+    Creating virtual environment at: foobar/.venv
     Resolved 2 packages in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
@@ -1702,7 +1702,7 @@ fn sync_custom_environment_path() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: bar
+    Creating virtual environment at: bar
     Resolved 2 packages in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
@@ -1723,7 +1723,7 @@ fn sync_custom_environment_path() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: [OTHER_TEMPDIR]/.venv
+    Creating virtual environment at: [OTHER_TEMPDIR]/.venv
     Resolved 2 packages in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
@@ -1803,7 +1803,7 @@ fn sync_workspace_custom_environment_path() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: foo
+    Creating virtual environment at: foo
     Resolved 3 packages in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
@@ -1959,7 +1959,7 @@ fn sync_virtual_env_warning() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: foo
+    Creating virtual environment at: foo
     Resolved 2 packages in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
@@ -1974,7 +1974,7 @@ fn sync_virtual_env_warning() -> Result<()> {
     ----- stderr -----
     warning: `VIRTUAL_ENV=foo` does not match the project environment path `bar` and will be ignored
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: bar
+    Creating virtual environment at: bar
     Resolved 2 packages in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
@@ -2036,7 +2036,7 @@ fn sync_update_project() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -2099,7 +2099,7 @@ fn sync_environment_prompt() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 2 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -26,7 +26,7 @@ fn create_venv() {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -44,7 +44,7 @@ fn create_venv() {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -64,7 +64,7 @@ fn create_venv_project_environment() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -94,7 +94,7 @@ fn create_venv_project_environment() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: foo
+    Creating virtual environment at: foo
     Activate with: source foo/bin/activate
     "###
     );
@@ -115,7 +115,7 @@ fn create_venv_project_environment() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -132,7 +132,7 @@ fn create_venv_project_environment() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: bar
+    Creating virtual environment at: bar
     Activate with: source bar/bin/activate
     "###
     );
@@ -150,7 +150,7 @@ fn create_venv_project_environment() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -162,7 +162,7 @@ fn create_venv_project_environment() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -182,7 +182,7 @@ fn create_venv_defaults_to_cwd() {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -203,7 +203,7 @@ fn create_venv_ignores_virtual_env_variable() {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -221,7 +221,7 @@ fn create_venv_reads_request_from_python_version_file() {
 
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -240,7 +240,7 @@ fn create_venv_reads_request_from_python_version_file() {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -260,7 +260,7 @@ fn create_venv_reads_request_from_python_versions_file() {
 
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -279,7 +279,7 @@ fn create_venv_reads_request_from_python_versions_file() {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -292,16 +292,16 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
     let context = TestContext::new_with_versions(&["3.11", "3.9", "3.10", "3.12"]);
 
     // Without a Python requirement, we use the first on the PATH
-    uv_snapshot!(context.filters(), context.venv(), @r#"
+    uv_snapshot!(context.filters(), context.venv(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
-    "#
+    "###
     );
 
     // With `requires-python = "<3.11"`, we prefer the first available version
@@ -322,7 +322,7 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.9.[X] interpreter at: [PYTHON-3.9]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -338,16 +338,16 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
         "#
     })?;
 
-    uv_snapshot!(context.filters(), context.venv(), @r#"
+    uv_snapshot!(context.filters(), context.venv(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
-    "#
+    "###
     );
 
     // With `requires-python = ">=3.11,<3.12"`, we prefer exact version (3.11)
@@ -361,16 +361,16 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
         "#
     })?;
 
-    uv_snapshot!(context.filters(), context.venv(), @r#"
+    uv_snapshot!(context.filters(), context.venv(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
-    "#
+    "###
     );
 
     // With `requires-python = ">=3.10"`, we prefer first compatible version (3.11)
@@ -395,16 +395,16 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
         "#
     })?;
 
-    uv_snapshot!(context.filters(), context.venv(), @r#"
+    uv_snapshot!(context.filters(), context.venv(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
-    "#
+    "###
     );
 
     // With `requires-python = ">3.11"`, we prefer first compatible version (3.11)
@@ -418,16 +418,16 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
         "#
     })?;
 
-    uv_snapshot!(context.filters(), context.venv(), @r#"
+    uv_snapshot!(context.filters(), context.venv(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
-    "#
+    "###
     );
 
     // With `requires-python = ">=3.12"`, we prefer first compatible version (3.12)
@@ -441,16 +441,16 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
         "#
     })?;
 
-    uv_snapshot!(context.filters(), context.venv(), @r#"
+    uv_snapshot!(context.filters(), context.venv(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
-    "#
+    "###
     );
 
     context.venv.assert(predicates::path::is_dir());
@@ -472,7 +472,7 @@ fn create_venv_ignores_missing_pyproject_metadata() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -497,7 +497,7 @@ fn create_venv_warns_user_on_requires_python_discovery_error() -> Result<()> {
     ----- stderr -----
     warning: Failed to parse: `pyproject.toml`
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -524,7 +524,7 @@ fn create_venv_explicit_request_takes_priority_over_python_version_file() {
 
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -546,7 +546,7 @@ fn seed() {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv with seed packages at: .venv
+    Creating virtual environment with seed packages at: .venv
      + pip==24.0
     Activate with: source .venv/bin/activate
     "###
@@ -569,7 +569,7 @@ fn seed_older_python_version() {
 
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
-    Creating virtualenv with seed packages at: .venv
+    Creating virtual environment with seed packages at: .venv
      + pip==24.0
      + setuptools==69.2.0
      + wheel==0.43.0
@@ -671,7 +671,7 @@ fn create_venv_python_patch() {
 
     ----- stderr -----
     Using Python 3.12.1 interpreter at: [PYTHON-3.12.1]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -696,7 +696,7 @@ fn file_exists() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     uv::venv::creation
 
       × Failed to create virtualenv
@@ -723,7 +723,7 @@ fn empty_dir_exists() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -751,11 +751,11 @@ fn non_empty_dir_exists() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     uv::venv::creation
 
       × Failed to create virtualenv
-      ╰─▶ The directory `.venv` exists, but it's not a virtualenv
+      ╰─▶ The directory `.venv` exists, but it's not a virtual environment
     "###
     );
 
@@ -781,11 +781,11 @@ fn non_empty_dir_exists_allow_existing() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     uv::venv::creation
 
       × Failed to create virtualenv
-      ╰─▶ The directory `.venv` exists, but it's not a virtualenv
+      ╰─▶ The directory `.venv` exists, but it's not a virtual environment
     "###
     );
 
@@ -800,7 +800,7 @@ fn non_empty_dir_exists_allow_existing() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -818,7 +818,7 @@ fn non_empty_dir_exists_allow_existing() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -863,7 +863,7 @@ fn windows_shims() -> Result<()> {
 
     ----- stderr -----
     Using Python 3.8.[X] interpreter at: [PYTHON-3.8]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );
@@ -890,7 +890,7 @@ fn virtualenv_compatibility() {
     ----- stderr -----
     warning: virtualenv's `--clear` has no effect (uv always clears the virtual environment)
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate
     "###
     );

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -27,7 +27,7 @@ fn create_venv() {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -45,7 +45,7 @@ fn create_venv() {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -65,7 +65,7 @@ fn create_venv_project_environment() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -95,7 +95,7 @@ fn create_venv_project_environment() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: foo
-    Activate with: source foo/bin/activate
+    Activate with: source foo/[BIN]/activate
     "###
     );
 
@@ -116,7 +116,7 @@ fn create_venv_project_environment() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -133,7 +133,7 @@ fn create_venv_project_environment() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: bar
-    Activate with: source bar/bin/activate
+    Activate with: source bar/[BIN]/activate
     "###
     );
 
@@ -151,7 +151,7 @@ fn create_venv_project_environment() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -163,7 +163,7 @@ fn create_venv_project_environment() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -183,7 +183,7 @@ fn create_venv_defaults_to_cwd() {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -204,7 +204,7 @@ fn create_venv_ignores_virtual_env_variable() {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 }
@@ -222,7 +222,7 @@ fn create_venv_reads_request_from_python_version_file() {
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -241,7 +241,7 @@ fn create_venv_reads_request_from_python_version_file() {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -261,7 +261,7 @@ fn create_venv_reads_request_from_python_versions_file() {
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -280,7 +280,7 @@ fn create_venv_reads_request_from_python_versions_file() {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -300,7 +300,7 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -323,7 +323,7 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
     ----- stderr -----
     Using Python 3.9.[X] interpreter at: [PYTHON-3.9]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -346,7 +346,7 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -369,7 +369,7 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -403,7 +403,7 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -426,7 +426,7 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -449,7 +449,7 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -473,7 +473,7 @@ fn create_venv_ignores_missing_pyproject_metadata() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -498,7 +498,7 @@ fn create_venv_warns_user_on_requires_python_discovery_error() -> Result<()> {
     warning: Failed to parse: `pyproject.toml`
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -525,7 +525,7 @@ fn create_venv_explicit_request_takes_priority_over_python_version_file() {
     ----- stderr -----
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -548,7 +548,7 @@ fn seed() {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment with seed packages at: .venv
      + pip==24.0
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -573,7 +573,7 @@ fn seed_older_python_version() {
      + pip==24.0
      + setuptools==69.2.0
      + wheel==0.43.0
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -672,7 +672,7 @@ fn create_venv_python_patch() {
     ----- stderr -----
     Using Python 3.12.1 interpreter at: [PYTHON-3.12.1]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -724,7 +724,7 @@ fn empty_dir_exists() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -801,7 +801,7 @@ fn non_empty_dir_exists_allow_existing() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -819,7 +819,7 @@ fn non_empty_dir_exists_allow_existing() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -864,7 +864,7 @@ fn windows_shims() -> Result<()> {
     ----- stderr -----
     Using Python 3.8.[X] interpreter at: [PYTHON-3.8]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 
@@ -891,7 +891,7 @@ fn virtualenv_compatibility() {
     warning: virtualenv's `--clear` has no effect (uv always clears the virtual environment)
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/bin/activate
+    Activate with: source .venv/[BIN]/activate
     "###
     );
 

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -379,7 +379,7 @@ fn test_uv_run_with_package_virtual_workspace() -> Result<()> {
     ----- stderr -----
     warning: `VIRTUAL_ENV=[VENV]/` does not match the project environment path `.venv` and will be ignored
     Using Python 3.12.[X] interpreter at: [PYTHON]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 8 packages in [TIME]
     Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
@@ -439,7 +439,7 @@ fn test_uv_run_virtual_workspace_root() -> Result<()> {
     ----- stderr -----
     warning: `VIRTUAL_ENV=[VENV]/` does not match the project environment path `.venv` and will be ignored
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 8 packages in [TIME]
     Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
@@ -484,7 +484,7 @@ fn test_uv_run_with_package_root_workspace() -> Result<()> {
     ----- stderr -----
     warning: `VIRTUAL_ENV=[VENV]/` does not match the project environment path `.venv` and will be ignored
     Using Python 3.12.[X] interpreter at: [PYTHON]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 8 packages in [TIME]
     Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
@@ -549,7 +549,7 @@ fn test_uv_run_isolate() -> Result<()> {
     ----- stderr -----
     warning: `VIRTUAL_ENV=[VENV]/` does not match the project environment path `.venv` and will be ignored
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtual environment at: .venv
     Resolved 8 packages in [TIME]
     Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -63,6 +63,14 @@ uv accepts the following command-line arguments as environment variables:
   `--no-python-downloads` option. Whether uv should allow Python downloads.
 - `UV_COMPILE_BYTECODE`: Equivalent to the `--compile-bytecode` command-line argument. If set, uv
   will compile Python source files to bytecode after installation.
+- `UV_PUBLISH_URL`: Equivalent to the `--publish-url` command-line argument. The URL of the upload
+  endpoint of the index to use with `uv publish`.
+- `UV_PUBLISH_TOKEN`: Equivalent to the `--token` command-line argument in `uv publish`. If
+  set, uv will use this token (with the username `__token__`) for publishing.
+- `UV_PUBLISH_USERNAME`: Equivalent to the `--username` command-line argument in `uv publish`. If
+  set, uv will use this username for publishing.
+- `UV_PUBLISH_PASSWORD`: Equivalent to the `--password` command-line argument in `uv publish`. If
+  set, uv will use this password for publishing.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -301,9 +301,14 @@ A [cache mount](https://docs.docker.com/build/guide/mounts/#add-a-cache-mount) c
 improve performance across builds:
 
 ```dockerfile title="Dockerfile"
+ENV UV_LINK_MODE=copy
+
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync
 ```
+
+Changing the default [`UV_LINK_MODE`](../../reference/settings.md#link-mode) silences warnings about
+not being able to use hard links since the cache and sync target are on separate file systems.
 
 If you're not mounting the cache, image size can be reduced by using the `--no-cache` flag or
 setting `UV_NO_CACHE`.

--- a/docs/guides/publish.md
+++ b/docs/guides/publish.md
@@ -1,10 +1,7 @@
 # Publishing a package
 
-uv supports building Python packages into source and binary distributions via `uv build`.
-
-As uv does not yet have a dedicated command for publishing packages, you can use the PyPA tool
-[`twine`](https://github.com/pypa/twine) to upload your package to a package registry, which can be
-invoked via `uvx`.
+uv supports building Python packages into source and binary distributions via `uv build` and
+uploading them to a registry with `uv publish`.
 
 ## Preparing your project for packaging
 
@@ -32,15 +29,20 @@ Alternatively, `uv build <SRC>` will build the package in the specified director
 
 ## Publishing your package
 
-Publish your package with `twine`:
+Publish your package with `uv publish`:
 
 ```console
-$ uvx twine upload dist/*
+$ uv publish
 ```
 
-!!! tip
+Set a PyPI token with `--token` or `UV_PUBLISH_TOKEN`, or set a username with `--username` or
+`UV_PUBLISH_USERNAME` and password with `--password` or `UV_PUBLISH_PASSWORD`.
 
-    To provide credentials, use the `TWINE_USERNAME` and `TWINE_PASSWORD` environment variables.
+!!! note
+
+    PyPI does not support publishing with username and password anymore, instead you need to
+    generate a token. Using a token is equivalent to setting `--username __token__` and using the
+    token as password.
 
 ## Installing your package
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ Initialized project `example` at `/home/user/example`
 $ cd example
 
 $ uv add ruff
-Creating virtualenv at: .venv
+Creating virtual environment at: .venv
 Resolved 2 packages in 170ms
    Built example @ file:///home/user/example
 Prepared 2 packages in 627ms
@@ -143,7 +143,7 @@ Download Python versions as needed:
 ```console
 $ uv venv --python 3.12.0
 Using Python 3.12.0
-Creating virtualenv at: .venv
+Creating virtual environment at: .venv
 Activate with: source .venv/bin/activate
 
 $ uv run --python pypy@3.8 -- python --version
@@ -211,7 +211,7 @@ Create a virtual environment:
 ```console
 $ uv venv
 Using Python 3.12.3
-Creating virtualenv at: .venv
+Creating virtual environment at: .venv
 Activate with: source .venv/bin/activate
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -38,6 +38,8 @@ uv [OPTIONS] <COMMAND>
 </dd>
 <dt><a href="#uv-build"><code>uv build</code></a></dt><dd><p>Build Python packages into source distributions and wheels</p>
 </dd>
+<dt><a href="#uv-publish"><code>uv publish</code></a></dt><dd><p>Upload distributions to an index</p>
+</dd>
 <dt><a href="#uv-cache"><code>uv cache</code></a></dt><dd><p>Manage uv&#8217;s cache</p>
 </dd>
 <dt><a href="#uv-version"><code>uv version</code></a></dt><dd><p>Display uv&#8217;s version</p>
@@ -6517,6 +6519,138 @@ uv build [OPTIONS] [SRC]
 </dd><dt><code>--version</code>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd><dt><code>--wheel</code></dt><dd><p>Build a binary distribution (&quot;wheel&quot;) from the given directory</p>
+
+</dd></dl>
+
+## uv publish
+
+Upload distributions to an index
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+uv publish [OPTIONS] [FILES]...
+```
+
+<h3 class="cli-reference">Arguments</h3>
+
+<dl class="cli-reference"><dt><code>FILES</code></dt><dd><p>The paths to the files to uploads, as glob expressions</p>
+
+</dd></dl>
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt><code>--allow-insecure-host</code> <i>allow-insecure-host</i></dt><dd><p>Allow insecure connections to a host.</p>
+
+<p>Can be provided multiple times.</p>
+
+<p>Expects to receive either a hostname (e.g., <code>localhost</code>), a host-port pair (e.g., <code>localhost:8080</code>), or a URL (e.g., <code>https://localhost</code>).</p>
+
+<p>WARNING: Hosts included in this list will not be verified against the system&#8217;s certificate store. Only use <code>--allow-insecure-host</code> in a secure network with verified sources, as it bypasses SSL verification and could expose you to MITM attacks.</p>
+
+<p>May also be set with the <code>UV_INSECURE_HOST</code> environment variable.</p>
+</dd><dt><code>--cache-dir</code> <i>cache-dir</i></dt><dd><p>Path to the cache directory.</p>
+
+<p>Defaults to <code>$HOME/Library/Caches/uv</code> on macOS, <code>$XDG_CACHE_HOME/uv</code> or <code>$HOME/.cache/uv</code> on Linux, and <code>%LOCALAPPDATA%\uv\cache</code> on Windows.</p>
+
+<p>May also be set with the <code>UV_CACHE_DIR</code> environment variable.</p>
+</dd><dt><code>--color</code> <i>color-choice</i></dt><dd><p>Control colors in output</p>
+
+<p>[default: auto]</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
+
+<li><code>always</code>:  Enables colored output regardless of the detected environment</li>
+
+<li><code>never</code>:  Disables colored output</li>
+</ul>
+</dd><dt><code>--config-file</code> <i>config-file</i></dt><dd><p>The path to a <code>uv.toml</code> file to use for configuration.</p>
+
+<p>While uv configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
+
+<p>May also be set with the <code>UV_CONFIG_FILE</code> environment variable.</p>
+</dd><dt><code>--help</code>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
+
+</dd><dt><code>--keyring-provider</code> <i>keyring-provider</i></dt><dd><p>Attempt to use <code>keyring</code> for authentication for remote requirements files.</p>
+
+<p>At present, only <code>--keyring-provider subprocess</code> is supported, which configures uv to use the <code>keyring</code> CLI to handle authentication.</p>
+
+<p>Defaults to <code>disabled</code>.</p>
+
+<p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>disabled</code>:  Do not use keyring for credential lookup</li>
+
+<li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
+</ul>
+</dd><dt><code>--native-tls</code></dt><dd><p>Whether to load TLS certificates from the platform&#8217;s native certificate store.</p>
+
+<p>By default, uv loads certificates from the bundled <code>webpki-roots</code> crate. The <code>webpki-roots</code> are a reliable set of trust roots from Mozilla, and including them in uv improves portability and performance (especially on macOS).</p>
+
+<p>However, in some cases, you may want to use the platform&#8217;s native certificate store, especially if you&#8217;re relying on a corporate trust root (e.g., for a mandatory proxy) that&#8217;s included in your system&#8217;s certificate store.</p>
+
+<p>May also be set with the <code>UV_NATIVE_TLS</code> environment variable.</p>
+</dd><dt><code>--no-cache</code>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
+
+<p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
+</dd><dt><code>--no-config</code></dt><dd><p>Avoid discovering configuration files (<code>pyproject.toml</code>, <code>uv.toml</code>).</p>
+
+<p>Normally, configuration files are discovered in the current directory, parent directories, or user configuration directories.</p>
+
+<p>May also be set with the <code>UV_NO_CONFIG</code> environment variable.</p>
+</dd><dt><code>--no-progress</code></dt><dd><p>Hide all progress outputs.</p>
+
+<p>For example, spinners or progress bars.</p>
+
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
+
+</dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
+
+<p>When disabled, uv will only use locally cached data and locally available files.</p>
+
+</dd><dt><code>--password</code>, <code>-p</code> <i>password</i></dt><dd><p>The password for the upload</p>
+
+<p>May also be set with the <code>UV_PUBLISH_PASSWORD</code> environment variable.</p>
+</dd><dt><code>--publish-url</code> <i>publish-url</i></dt><dd><p>The URL to the upload endpoint. Note: This is usually not the same as the index URL.</p>
+
+<p>The default value is publish URL for PyPI (&lt;https://upload.pypi.org/legacy/&gt;).</p>
+
+<p>May also be set with the <code>UV_PUBLISH_URL</code> environment variable.</p>
+</dd><dt><code>--python-preference</code> <i>python-preference</i></dt><dd><p>Whether to prefer uv-managed or system Python installations.</p>
+
+<p>By default, uv prefers using Python versions it manages. However, it will use system Python installations if a uv-managed Python is not installed. This option allows prioritizing or ignoring system Python installations.</p>
+
+<p>May also be set with the <code>UV_PYTHON_PREFERENCE</code> environment variable.</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>only-managed</code>:  Only use managed Python installations; never use system Python installations</li>
+
+<li><code>managed</code>:  Prefer managed Python installations over system Python installations</li>
+
+<li><code>system</code>:  Prefer system Python installations over managed Python installations</li>
+
+<li><code>only-system</code>:  Only use system Python installations; never use managed Python installations</li>
+</ul>
+</dd><dt><code>--quiet</code>, <code>-q</code></dt><dd><p>Do not print any output</p>
+
+</dd><dt><code>--token</code>, <code>-t</code> <i>token</i></dt><dd><p>The token for the upload.</p>
+
+<p>Using a token is equivalent to using <code>__token__</code> as username and using the token as password.</p>
+
+<p>May also be set with the <code>UV_PUBLISH_TOKEN</code> environment variable.</p>
+</dd><dt><code>--username</code>, <code>-u</code> <i>username</i></dt><dd><p>The username for the upload</p>
+
+<p>May also be set with the <code>UV_PUBLISH_USERNAME</code> environment variable.</p>
+</dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+
+<p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
+
+</dd><dt><code>--version</code>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1073,6 +1073,32 @@ Whether to enable experimental, preview features.
 
 ---
 
+### [`publish-url`](#publish-url) {: #publish-url }
+
+The URL for publishing packages to the Python package index (by default:
+<https://upload.pypi.org/legacy>).
+
+**Default value**: `"https://upload.pypi.org/legacy"`
+
+**Type**: `str`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.uv]
+    publish-url = "https://test.pypi.org/simple"
+    ```
+=== "uv.toml"
+
+    ```toml
+    
+    publish-url = "https://test.pypi.org/simple"
+    ```
+
+---
+
 ### [`python-downloads`](#python-downloads) {: #python-downloads }
 
 Whether to allow Python downloads.

--- a/scripts/publish/.gitignore
+++ b/scripts/publish/.gitignore
@@ -1,0 +1,1 @@
+astral-test-*

--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -1,0 +1,159 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "httpx>=0.27,<0.28",
+#     "packaging>=24.1,<25",
+# ]
+# ///
+
+"""
+Test `uv publish` by uploading a new version of astral-test-<test case> to testpypi,
+authenticating by one of various options.
+
+# Setup
+
+**astral-test-token**
+Set the `UV_TEST_PUBLISH_TOKEN` environment variables.
+
+**astral-test-password**
+Set the `UV_TEST_PUBLISH_PASSWORD` environment variable.
+This project also uses token authentication since it's the only thing that PyPI
+supports, but they both CLI options.
+TODO(konsti): Add an index for testing that supports username/password.
+
+**astral-test-keyring**
+```console
+uv pip install keyring
+keyring set https://test.pypi.org/legacy/?astral-test-keyring __token__
+```
+The query parameter a horrible hack stolen from
+https://github.com/pypa/twine/issues/565#issue-555219267
+to prevent the other projects from implicitly using the same credentials.
+"""
+
+import os
+import re
+from argparse import ArgumentParser
+from pathlib import Path
+from shutil import rmtree
+from subprocess import check_call
+
+import httpx
+from packaging.utils import parse_sdist_filename, parse_wheel_filename
+
+cwd = Path(__file__).parent
+
+
+def get_new_version(project_name: str) -> str:
+    """Return the next free path version on pypi"""
+    index_page = f"https://test.pypi.org/simple/{project_name}/?format=application/vnd.pypi.simple.v1+json"
+    data = httpx.get(index_page).json()
+    versions = set()
+    for file in data["files"]:
+        if file["filename"].endswith(".whl"):
+            [_name, version, _build, _tags] = parse_wheel_filename(file["filename"])
+        else:
+            [_name, version] = parse_sdist_filename(file["filename"])
+        versions.add(version)
+    max_version = max(versions)
+
+    # Bump the path version to obtain an empty version
+    release = list(max_version.release)
+    release[-1] += 1
+    return ".".join(str(i) for i in release)
+
+
+def create_project(project_name: str, uv: Path):
+    if cwd.joinpath(project_name).exists():
+        rmtree(cwd.joinpath(project_name))
+    check_call([uv, "init", "--lib", project_name], cwd=cwd)
+    pyproject_toml = cwd.joinpath(project_name).joinpath("pyproject.toml")
+
+    # Set to an unclaimed version
+    toml = pyproject_toml.read_text()
+    new_version = get_new_version(project_name)
+    toml = re.sub('version = ".*"', f'version = "{new_version}"', toml)
+    pyproject_toml.write_text(toml)
+
+
+def publish_project(project_name: str, uv: Path):
+    # Create the project
+    create_project(project_name, uv)
+
+    # Build the project
+    check_call([uv, "build"], cwd=cwd.joinpath(project_name))
+
+    # Upload the project
+    if project_name == "astral-test-token":
+        env = os.environ.copy()
+        env["UV_PUBLISH_TOKEN"] = os.environ["UV_TEST_PUBLISH_TOKEN"]
+        check_call(
+            [
+                uv,
+                "publish",
+                "--publish-url",
+                "https://test.pypi.org/legacy/",
+            ],
+            cwd=cwd.joinpath(project_name),
+            env=env,
+        )
+    elif project_name == "astral-test-password":
+        env = os.environ.copy()
+        env["UV_PUBLISH_PASSWORD"] = os.environ["UV_TEST_PUBLISH_PASSWORD"]
+        check_call(
+            [
+                uv,
+                "publish",
+                "--publish-url",
+                "https://test.pypi.org/legacy/",
+                "--username",
+                "__token__",
+            ],
+            cwd=cwd.joinpath(project_name),
+            env=env,
+        )
+    elif project_name == "astral-test-keyring":
+        check_call(
+            [
+                uv,
+                "publish",
+                "--publish-url",
+                "https://test.pypi.org/legacy/?astral-test-keyring",
+                "--username",
+                "__token__",
+                "--keyring-provider",
+                "subprocess",
+            ],
+            cwd=cwd.joinpath(project_name),
+        )
+    else:
+        raise ValueError(f"Unknown project name: {project_name}")
+
+
+def main():
+    parser = ArgumentParser()
+    projects = ["astral-test-token", "astral-test-password", "astral-test-keyring"]
+    parser.add_argument("projects", choices=projects + ["all"], nargs="+")
+    parser.add_argument("--uv")
+    args = parser.parse_args()
+
+    if args.uv:
+        # We change the working directory for the subprocess calls, so we have to
+        # absolutize the path.
+        uv = Path.cwd().joinpath(args.uv)
+    else:
+        check_call(["cargo", "build"])
+        executable_suffix = ".exe" if os.name == "nt" else ""
+        uv = cwd.parent.parent.joinpath(f"target/debug/uv{executable_suffix}")
+
+    if args.projects == ["all"]:
+        projects = projects
+    else:
+        projects = args.projects
+        
+    for project_name in projects:
+        publish_project(project_name, uv)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -330,6 +330,14 @@
         "null"
       ]
     },
+    "publish-url": {
+      "description": "The URL for publishing packages to the Python package index (by default: <https://upload.pypi.org/legacy>).",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri"
+    },
     "python-downloads": {
       "description": "Whether to allow Python downloads.",
       "anyOf": [

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1230,9 +1230,13 @@
             },
             "subdirectory": {
               "description": "The path to the directory with the `pyproject.toml`, if it's not in the archive root.",
-              "type": [
-                "string",
-                "null"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/String"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "tag": {
@@ -1253,9 +1257,13 @@
           "properties": {
             "subdirectory": {
               "description": "For source distributions, the path to the directory with the `pyproject.toml`, if it's not in the archive root.",
-              "type": [
-                "string",
-                "null"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/String"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "url": {
@@ -1280,7 +1288,7 @@
               ]
             },
             "path": {
-              "type": "string"
+              "$ref": "#/definitions/String"
             }
           },
           "additionalProperties": false
@@ -1336,7 +1344,7 @@
               "type": "string"
             },
             "path": {
-              "type": "string"
+              "$ref": "#/definitions/String"
             },
             "rev": {
               "type": [
@@ -1345,9 +1353,13 @@
               ]
             },
             "subdirectory": {
-              "type": [
-                "string",
-                "null"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/String"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "tag": {


### PR DESCRIPTION
The `uv publish` command allows uploading wheels and source distributions to PyPI or another registry. We support username/password auth, token auth and (follow-up) trusted publishing from GitHub Actions. Be default we upload files from `dist/*`, the output directory from `uv build`.

This is intended to support three different workflow, ordered by relevance:

1. Publishing a pure Python package from CI
* Call `uv build`
* Clear the venv, install the wheel, run a smoke test
* Clear the venv, install the source distribution, run a smoke test
* Call `uv publish`

2. Publishing a native module package from CI
* In one job, call `uv build`, clear the venv, install the source distribution, run a smoke test, upload the source distribution as artifact
* For each target, run a job, call `uv build --wheel`, clear the venv, install the wheel run a smoke test, upload the wheel as artifact
* In a final job, download all artifacts to `dist/*` and run `uv publish`

3. Publishing from a developer machine
* Call `uv build`
* Do a manual test routine
* Call `uv publish`

Since we intend for smoke tests, there is no combined build-and-publish command.

What works:
* Basic upload to pypi with token or username/password (username must be `__token__`, but it uses the same HTTP headers)
* Keyring integration. If you use scoped tokens, you need use url-string hacks such as https://github.com/pypa/twine/issues/565#issue-555219267 to differentiate the tokens, a problem we share with twine. 
* Error messages
* Testing on CI. Every time something in the upload crate or its test script changes, we upload a new version of dummy packages to testpypi

Next PRs: 
* Trusted publishing from GitHub actions with OIDC, and testing for it.

What's missing:
* Other registries?
